### PR TITLE
per hook enable/disable option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -187,6 +187,7 @@ paths can optionally be defined as dictionaries, e.g.::
     my_route53_hook:
       path: stacker.hooks.route53.create_domain:
       required: true
+      enabled: true
       args:
         domain: mydomain.com
   stacks:
@@ -203,8 +204,9 @@ Pre & Post Hooks
 ----------------
 
 Many actions allow for pre & post hooks. These are python methods that are
-executed before, and after the action is taken for the entire config. Only the
-following actions allow pre/post hooks:
+executed before, and after the action is taken for the entire config. Hooks 
+can be enabled or disabled, per hook. Only the following actions allow
+pre/post hooks:
 
 * build (keywords: *pre_build*, *post_build*)
 * destroy (keywords: *pre_destroy*, *post_destroy*)
@@ -221,6 +223,10 @@ The keyword is a list of dictionaries with the following keys:
   in the context.hook_data with the data_key as it's key.
 **required:**
   whether to stop execution if the hook fails
+**enabled:**
+  whether to execute the hook every stacker run. Default: True. This is a bool
+  that grants you the ability to execute a hook per environment when combined
+  with a variable pulled from an environment file.
 **args:**
   a dictionary of arguments to pass to the hook
 
@@ -230,6 +236,19 @@ the build action::
   pre_build:
     - path: stacker.hooks.route53.create_domain
       required: true
+      enabled: true
+      args:
+        domain: mydomain.com
+
+An example of a hook using the ``create_domain_bool`` variable from the environment
+file to determine if hook should run. Set ``create_domain_bool: true`` or
+``create_domain_bool: false`` in the environment file to determine if the hook
+should run in the environment stacker is running against::
+
+  pre_build:
+    - path: stacker.hooks.route53.create_domain
+      required: true
+      enabled: ${create_domain_bool}
       args:
         domain: mydomain.com
 

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -263,6 +263,8 @@ class Hook(Model):
 
     required = BooleanType(default=True)
 
+    enabled = BooleanType(default=True)
+
     data_key = StringType(serialize_when_none=False)
 
     args = DictType(AnyType)

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -425,6 +425,7 @@ def upload_lambda_functions(context, provider, **kwargs):
             pre_build:
               - path: stacker.hooks.aws_lambda.upload_lambda_functions
                 required: true
+                enabled: true
                 data_key: lambda
                 args:
                   bucket: custom-bucket

--- a/stacker/hooks/command.py
+++ b/stacker/hooks/command.py
@@ -48,11 +48,13 @@ def run_command(provider, context, command, capture=False, interactive=False,
             pre_build:
               - path: stacker.hooks.command.run_command
                 required: true
+                enabled: true
                 data_key: copy_env
                 args:
                   command: ['cp', 'environment.template', 'environment']
               - path: stacker.hooks.command.run_command
                 required: true
+                enabled: true
                 data_key: get_git_commit
                 args:
                   command: ['git', 'rev-parse', 'HEAD']

--- a/stacker/tests/fixtures/vpc-bastion-db-web-pre-1.0.yaml
+++ b/stacker/tests/fixtures/vpc-bastion-db-web-pre-1.0.yaml
@@ -5,6 +5,7 @@
 pre_build:
   - path: stacker.hooks.route53.create_domain
     required: true
+    enabled: true
     # Additional args can be passed as a dict of key/value pairs
     # args:
     #   BaseDomain: foo

--- a/stacker/tests/fixtures/vpc-bastion-db-web.yaml
+++ b/stacker/tests/fixtures/vpc-bastion-db-web.yaml
@@ -5,6 +5,7 @@
 pre_build:
   - path: stacker.hooks.route53.create_domain
     required: true
+    enabled: true
     # Additional args can be passed as a dict of key/value pairs
     # args:
     #   BaseDomain: foo

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -211,21 +211,25 @@ stacks: []
         pre_build:
           - path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         post_build:
           - path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         pre_destroy:
           - path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         post_destroy:
           - path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         package_sources:
@@ -269,24 +273,28 @@ stacks: []
           prebuild_createdomain:
             path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         post_build:
           postbuild_createdomain:
             path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         pre_destroy:
           predestroy_createdomain:
             path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         post_destroy:
           postdestroy_createdomain:
             path: stacker.hooks.route53.create_domain
             required: true
+            enabled: true
             args:
               domain: mydomain.com
         package_sources:

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -339,6 +339,23 @@ class TestHooks(unittest.TestCase):
         with self.assertRaises(Queue.Empty):
             hook_queue.get_nowait()
 
+    def test_valid_enabled_hook(self):
+        hooks = [
+            Hook({"path": "stacker.tests.test_util.mock_hook",
+                  "required": True, "enabled": True})]
+        handle_hooks("missing", hooks, self.provider, self.context)
+        good = hook_queue.get_nowait()
+        self.assertEqual(good["provider"].region, "us-east-1")
+        with self.assertRaises(Queue.Empty):
+            hook_queue.get_nowait()
+
+    def test_valid_enabled_false_hook(self):
+        hooks = [
+            Hook({"path": "stacker.tests.test_util.mock_hook",
+                  "required": True, "enabled": False})]
+        handle_hooks("missing", hooks, self.provider, self.context)
+        self.assertTrue(hook_queue.empty())
+
     def test_context_provided_to_hook(self):
         hooks = [
             Hook({"path": "stacker.tests.test_util.context_hook",

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -354,6 +354,11 @@ def handle_hooks(stage, hooks, provider, context):
         data_key = hook.data_key
         required = hook.required
         kwargs = hook.args or {}
+        enabled = hook.enabled
+        if not enabled:
+            logger.debug("hook with method %s is disabled, skipping",
+                         hook.path)
+            continue
         try:
             method = load_object_from_string(hook.path)
         except (AttributeError, ImportError):


### PR DESCRIPTION
Background: I ran into a situation where I needed to execute a post_build hook only in a single environment. I assumed that I could set `enabled: false` per hook, like I can with stacks.  Well... now we can!