### PR TITLE
Add `add_output` helper method on Blueprints

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -6,9 +6,10 @@ from stacker.util import read_value_from_path
 from stacker.variables import Variable
 
 from troposphere import (
+    Output,
     Parameter,
     Ref,
-    Template
+    Template,
 )
 
 from ..exceptions import (
@@ -521,6 +522,15 @@ class Blueprint(object):
 
         """
         self.template.add_description(description)
+
+    def add_output(self, name, value):
+        """Simple helper for adding outputs.
+
+        Args:
+            name (str): The name of the output to create.
+            value (str): The value to put in the output.
+        """
+        self.template.add_output(Output(name, Value=value))
 
     @property
     def requires_change_set(self):

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -96,6 +96,25 @@ class TestBlueprintRendering(unittest.TestCase):
         )
 
 
+class TestBaseBlueprint(unittest.TestCase):
+    def test_add_output(self):
+        output_name = "MyOutput1"
+        output_value = "OutputValue"
+
+        class TestBlueprint(Blueprint):
+            VARIABLES = {}
+
+            def create_template(self):
+                self.template.add_version('2010-09-09')
+                self.template.add_description('TestBlueprint')
+                self.add_output(output_name, output_value)
+
+        bp = TestBlueprint(name="test", context=mock_context())
+        bp.render_template()
+        self.assertEqual(bp.template.outputs[output_name].properties["Value"],
+                         output_value)
+
+
 class TestVariables(unittest.TestCase):
 
     def test_defined_variables(self):


### PR DESCRIPTION
Got sick of constantly typing `Output("Blah", Value="foo")` and figured
we could make this easier.