### PR TITLE
Only run a single functional test at a time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,14 @@ workflows:
             - lint
       - functional-test-35:
           requires:
+            - functional-test-27
             - unit-test-35
       - unit-test-36:
           requires:
             - lint
       - functional-test-36:
           requires:
+            - functional-test-35
             - unit-test-36
 
 


### PR DESCRIPTION
When we do these in parallel it seems to lead to a lot of instability.