### PR TITLE
Sometimes we miss the rolling back message

### DIFF
--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -697,7 +697,6 @@ EOF
   assert "$status" -eq 1
   assert_has_line "Using default AWS provider mode"
   assert_has_line "recreate-failed-interactive: submitted (creating new stack)"
-  assert_has_line "recreate-failed-interactive: submitted (rolling back new stack)"
   assert_has_line "recreate-failed-interactive: failed (rolled back new stack)"
 
   # Updating the stack should prompt to re-create it.


### PR DESCRIPTION
Because the speed that we rollback at is very quick, sometimes stacker
doesn't poll fast enough to catch that we are in a rolling back state.
Knowing that we rolled back should be good enough.