### PR TITLE
Formalize the existence of external (read-only) stacks

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -362,7 +362,10 @@ Managed Stack Configuration
 External Stack Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-External stacks have no additional configuration options.
+.. literalinclude:: stack-config-external.yml
+   :language: yaml
+   :name: stack-config-external
+
 
 Stacks Example
 ~~~~~~~~~~~~~~

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,3 +1,5 @@
+.. highlight:: yaml
+
 =============
 Configuration
 =============
@@ -324,73 +326,43 @@ Stacks
 ------
 
 This is the core part of the config - this is where you define each of the
-stacks that will be deployed in the environment.  The top level keyword
-*stacks* is populated with a list of dictionaries, each representing a single
-stack to be built.
+stacks that will be part of your environment.
+The top level keyword ``stacks`` is populated with a list of dictionaries, each
+representing a single stack.
 
-A stack has the following keys:
+Stacks can be classified as:
 
-**name:**
-  The logical name for this stack, which can be used in conjuction with the
-  ``output`` lookup. The value here must be unique within the config. If no
-  ``stack_name`` is provided, the value here will be used for the name of the
-  CloudFormation stack.
-**class_path:**
-  The python class path to the Blueprint to be used. Specify this or
-  ``template_path`` for the stack.
-**template_path:**
-  Path to raw CloudFormation template (JSON or YAML). Specify this or
-  ``class_path`` for the stack.
-**description:**
-  A short description to apply to the stack. This overwrites any description
-  provided in the Blueprint. See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html
-**variables:**
-  A dictionary of Variables_ to pass into the Blueprint when rendering the
-  CloudFormation template. Variables_ can be any valid YAML data
-  structure.
-**locked:**
-  (optional) If set to true, the stack is locked and will not be
-  updated unless the stack is passed to stacker via the *--force* flag.
-  This is useful for *risky* stacks that you don't want to take the
-  risk of allowing CloudFormation to update, but still want to make
-  sure get launched when the environment is first created. When ``locked``,
-  it's not necessary to specify a ``class_path`` or ``template_path``.
-**enabled:**
-  (optional) If set to false, the stack is disabled, and will not be
-  built or updated. This can allow you to disable stacks in different
-  environments.
-**protected:**
-  (optional) When running an update in non-interactive mode, if a stack has
-  *protected* set to *true* and would get changed, stacker will switch to
-  interactive mode for that stack, allowing you to approve/skip the change.
-**requires:**
-  (optional) a list of other stacks this stack requires. This is for explicit
-  dependencies - you do not need to set this if you refer to another stack in
-  a Parameter, so this is rarely necessary.
-**tags:**
-  (optional) a dictionary of CloudFormation tags to apply to this stack. This
-  will be combined with the global tags, but these tags will take precendence.
-**stack_name:**
-  (optional) If provided, this will be used as the name of the CloudFormation
-  stack. Unlike ``name``, the value doesn't need to be unique within the config,
-  since you could have multiple stacks with the same name, but in different
-  regions or accounts. (note: the namespace from the environment will be
-  prepended to this)
-**region**:
-  (optional): If provided, specifies the name of the region that the
-  CloudFormation stack should reside in. If not provided, the default region
-  will be used (``AWS_DEFAULT_REGION``, ``~/.aws/config`` or the ``--region``
-  flag). If both ``region`` and ``profile`` are specified, the value here takes
-  precedence over the value in the profile.
-**profile**:
-  (optional): If provided, specifies the name of a AWS profile to use when
-  performing AWS API calls for this stack. This can be used to provision stacks
-  in multiple accounts or regions.
-**stack_policy_path**:
-  (optional): If provided, specifies the path to a JSON formatted stack policy
-  that will be applied when the CloudFormation stack is created and updated.
-  You can use stack policies to prevent CloudFormation from making updates to
-  protected resources (e.g. databases). See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
+Managed
+  Stacks that are fully managed by the current Stacker configuration.
+  They will be created, updated or destroyed as needed.
+External
+  Stacks that will not be modified by the current Stacker configuration.
+  They will only have their outputs loaded to be used as lookups for local
+  stacks, and are effectively "read only".
+  Use them when you need information from stacks in different accounts or
+  regions, that are part of a different Stacker config, or deployed by other
+  tools.
+
+Basic Stack Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: stack-config-basic.yml
+   :language: yaml
+   :name: stack-config-basic
+
+
+Managed Stack Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: stack-config-managed.yml
+   :language: yaml
+   :name: stack-config-managed
+
+
+External Stack Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+External stacks have no additional configuration options.
 
 Stacks Example
 ~~~~~~~~~~~~~~
@@ -418,9 +390,12 @@ Here's an example from stacker_blueprints_, used to create a VPC::
           - 10.128.16.0/22
           - 10.128.20.0/22
         CidrBlock: 10.128.0.0/16
+    - name: external-vpc-example
+      stack_name: my-dev-account-vpc
+      profile: dev
 
 Variables
-==========
+=========
 
 Variables are values that will be passed into a `Blueprint
 <blueprints.html>`_ before it is

--- a/docs/stack-config-basic.yml
+++ b/docs/stack-config-basic.yml
@@ -1,0 +1,31 @@
+# name (str): The logical name for the stack, which can be used in conjunction
+# with the output`lookup. The value here must be unique within the whole config.
+# If ``stack_name`` is not provided, it will also determine the name of the
+# stack submitted to CloudFormation (after prepending the configured
+# ``stacker_namespace``)
+name: my-stack/prod
+
+# stack_name (str, optional): Physical name of the stack to be submitted to
+# CloudFormation (after prepending the configured ``stacker_namespace``).
+# Unlike ``name``, this does not need to be unique within the config, as
+# multiple stacks with the same name can be present in different AWS accounts
+# and/or regions.
+stack_name: production-my-stack
+
+# region (str, optional): Name of the region that the CloudFormation stack
+# should reside in. If not provided, the default region will be used (from the
+# ``AWS_DEFAULT_REGION`` env var, ``~/.aws/config`` or the ``--region`` flag).
+# If both ``region`` and ``profile`` are specified, this value takes precedence
+# over the value in the profile.
+region: us-west-1
+
+# profile (str, optional): Name of the AWS profile to use when performing AWS
+# API calls for this stack. This can be used to provision stacks in multiple
+# accounts or regions.
+profile: production-automation
+
+# external (bool, optional): Whether this stack should be marked as external,
+# disabling any kind of modifications to it by Stacker. Such read-only stacks
+# can provide outputs to other managed stacks using different profiles or
+# regions.
+external: false

--- a/docs/stack-config-external.yml
+++ b/docs/stack-config-external.yml
@@ -1,0 +1,5 @@
+# fqn (str, optional): Fully-qualified physical name of the stack to be loaded
+# from CloudFormation. Use instead of ``stack_name`` if the stack lies in a
+# different namespace, as this value *does not* get the namespace prepended
+# to it
+fqn: development-my-stack

--- a/docs/stack-config-managed.yml
+++ b/docs/stack-config-managed.yml
@@ -1,0 +1,69 @@
+# class_path (str, optional): The Python class path to the Blueprint to be
+# used. Either this or``template_path`` must be specified to manage a stack.
+class_path: my.package.MyBlueprint
+
+# template_path (str, optional): The path to a file containing a raw
+# Cloudformation template, in JSON or YAML format. Either this or ``class_path``
+# must be specified to manage a stack.
+template_path: stacks/VPC.yaml
+
+# description (str, optional): A short description to apply to the stack. This
+# overrides any description provided in the Blueprint. See the
+# `AWS Documentation`_ for more information.
+#
+# .. _AWS Documentation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html
+description: This Stack is managed by Stacker.
+
+# variables (dict): A dictionary of Variables_ to pass into the Blueprint when
+# rendering the CloudFormation template. Variables_ can be any valid YAML data
+# structure. The expected types are determined by the chosen Blueprint class or
+# template.
+variables:
+  MyString: string-value
+  MyIntList:
+  - 1
+  - 2
+  - 3
+
+# locked (bool, optional): If set to true, the stack is locked and will not be
+# updated unless ``--force`` flag is passed and includes its name.
+# This is useful for sensitive stacks that should not be updated without an
+# abundance of care.
+# Due to backwards compatibility, there is no need to specify a class or
+# template if this is enabled, but if possible, use the ``external`` option
+# instead.
+locked: false
+
+# enabled (bool, optional); If set to false, the stack is disabled, and will not
+# be created or updated. This can allow you to disable stacks temporarily, or
+# selectively in different environments.
+enabled: true
+
+# protected (bool, optional): If set to true, When running an update in
+# non-interactive mode, and the stack would be modified,  Stacker will
+# switch to interactive mode before applying the changes, allowing you to
+# approve/skip the change.
+protected: false
+
+# requires (list of str, optional): A list of other stack names that must be
+# created/updated before this stack. This is not needed on normal usages, as
+# dependencies are automatically created when using an output from a stack in
+# the variables of another stack. Use it when you know that a hidden dependency
+# exists (or one is documented in the CloudFormation reference).
+dependencies:
+  - a-parent-stack
+  - other-parent-stack
+
+# tags (dict, optional): CloudFormation tags to apply to this stack. These
+# will be combined with (and possibly override) the global tags.
+tags:
+  Service: my-service
+  Department: my-department
+
+# stack_policy_path (str, optional):  path to a JSON formatted stack policy to
+# be applied when the stack is created and updated. You can use stack policies
+# to prevent CloudFormation from making updates to protected resources (e.g.
+# databases). See the `AWS Documentation`_ for more information.
+#
+# .. _AWS Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
+stack_policy_path: policies/disable-delete-bucket.json

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "PyYAML>=3.12",
     "awacs>=0.6.0",
     "gitpython~=2.0",
-    "schematics~=2.0.1",
+    "schematics~=2.1.0",
     "formic2",
 ]
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -36,53 +36,6 @@ def build_stack_tags(stack):
     return [{'Key': t[0], 'Value': t[1]} for t in stack.tags.items()]
 
 
-def should_update(stack):
-    """Tests whether a stack should be submitted for updates to CF.
-
-    Args:
-        stack (:class:`stacker.stack.Stack`): The stack object to check.
-
-    Returns:
-        bool: If the stack should be updated, return True.
-
-    """
-
-    if not stack.blueprint:
-        return False
-
-    if stack.locked:
-        if not stack.force:
-            logger.debug("Stack %s locked and not in --force list. "
-                         "Refusing to update.", stack.name)
-            return False
-        else:
-            logger.debug("Stack %s locked, but is in --force "
-                         "list.", stack.name)
-    return True
-
-
-def should_submit(stack):
-    """Tests whether a stack should be submitted to CF for update/create
-
-    Args:
-        stack (:class:`stacker.stack.Stack`): The stack object to check.
-
-    Returns:
-        bool: If the stack should be submitted, return True.
-
-    """
-
-    # Submit stack without a blueprint just to grab outputs
-    if not stack.blueprint:
-        return True
-
-    if stack.enabled:
-        return True
-
-    logger.debug("Stack %s is not enabled.  Skipping.", stack.name)
-    return False
-
-
 def should_ensure_cfn_bucket(outline, dump):
     """Test whether access to the cloudformation template bucket is required
 
@@ -243,7 +196,7 @@ class Action(BaseAction):
         if self.cancel.wait(wait_time):
             return INTERRUPTED
 
-        if not should_submit(stack):
+        if not stack.should_submit():
             return NotSubmittedStatus()
 
         provider = self.build_provider(stack)
@@ -253,7 +206,7 @@ class Action(BaseAction):
         except StackDoesNotExist:
             provider_stack = None
 
-        if provider_stack and not should_update(stack):
+        if provider_stack and not stack.should_update():
             stack.set_outputs(
                 self.provider.get_output_dict(provider_stack))
             return NotUpdatedStatus()

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -46,6 +46,10 @@ def should_update(stack):
         bool: If the stack should be updated, return True.
 
     """
+
+    if not stack.blueprint:
+        return False
+
     if stack.locked:
         if not stack.force:
             logger.debug("Stack %s locked and not in --force list. "
@@ -67,6 +71,11 @@ def should_submit(stack):
         bool: If the stack should be submitted, return True.
 
     """
+
+    # Submit stack without a blueprint just to grab outputs
+    if not stack.blueprint:
+        return True
+
     if stack.enabled:
         return True
 

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -214,10 +214,10 @@ class Action(build.Action):
         if self.cancel.wait(0):
             return INTERRUPTED
 
-        if not build.should_submit(stack):
+        if not stack.should_submit():
             return NotSubmittedStatus()
 
-        if not build.should_update(stack):
+        if not stack.should_update():
             return NotUpdatedStatus()
 
         provider = self.build_provider(stack)

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -12,7 +12,12 @@ from string import Template
 
 from schematics import Model
 from schematics.exceptions import ValidationError
-from schematics.exceptions import BaseError as SchematicsError
+from schematics.exceptions import (
+    BaseError as SchematicsError,
+    UndefinedValueError,
+    UnknownFieldError
+)
+
 from schematics.types import (
     BaseType,
     BooleanType,
@@ -137,19 +142,9 @@ def parse(raw_config):
                     tmp_list.append(tmp_dict)
                 config_dict[top_level_key] = tmp_list
 
-    # We have to enable non-strict mode, because people may be including top
-    # level keys for re-use with stacks (e.g. including something like
-    # `common_variables: &common_variables`).
-    #
-    # The unfortunate side effect of this is that it propagates down to every
-    # schematics model, and there doesn't seem to be a good way to only disable
-    # strict mode on a single model.
-    #
-    # If we enabled strict mode, it would break backwards compatibility, so we
-    # should consider enabling this in the future.
-    strict = False
-
-    return Config(config_dict, strict=strict)
+    # Top-level excess keys are removed by Config._convert, so enabling strict
+    # mode is fine here.
+    return Config(config_dict, strict=True)
 
 
 def load(config):
@@ -422,9 +417,36 @@ class Config(Model):
         PolyModelType([ExternalStack, Stack]),
         default=[], validators=[not_empty_list])
 
-    def validate(self):
+    def _remove_excess_keys(self, data):
+        excess_keys = set(data.keys())
+        excess_keys -= self._schema.valid_input_keys
+        if not excess_keys:
+            return data
+
+        logger.debug('Removing excess keys from config input: %s',
+                     excess_keys)
+        clean_data = data.copy()
+        for key in excess_keys:
+            del clean_data[key]
+
+        return clean_data
+
+    def _convert(self, raw_data=None, context=None, **kwargs):
+        if raw_data is not None:
+            # Remove excess top-level keys, since we want to allow them to be
+            # used for custom user variables to be reference later. This is
+            # preferable to just disabling strict mode, as we can still
+            # disallow excess keys in the inner models.
+            raw_data = self._remove_excess_keys(raw_data)
+
+        return super(Config, self)._convert(raw_data=raw_data, context=context,
+                                            **kwargs)
+
+    def validate(self, *args, **kwargs):
         try:
-            super(Config, self).validate()
+            return super(Config, self).validate(*args, **kwargs)
+        except (UndefinedValueError, UnknownFieldError) as e:
+            raise exceptions.InvalidConfig([e.message])
         except SchematicsError as e:
             raise exceptions.InvalidConfig(e.errors)
 

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -288,6 +288,8 @@ class BaseStack(Model):
 
 
 class ExternalStack(BaseStack):
+    fqn = StringType(serialize_when_none=False)
+
     @classmethod
     def _claim_polymorphic(cls, value):
         if value.get("external", False) is True:
@@ -296,6 +298,12 @@ class ExternalStack(BaseStack):
     def __init__(self, *args, **kwargs):
         super(ExternalStack, self).__init__(*args, **kwargs)
         self.external = True
+
+    def validate_fqn(self, data, value):
+        if (not value and not data["stack_name"]) or \
+           (value and data["stack_name"]):
+            raise ValidationError("Exactly one of `fqn` and `stack_name` must "
+                                  "be provided for external stacks")
 
 
 class Stack(BaseStack):

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -147,10 +147,7 @@ class Context(object):
                         definition=stack_def,
                         context=self,
                         mappings=self.mappings,
-                        force=stack_def.name in self.force_stacks,
-                        locked=stack_def.locked,
-                        enabled=stack_def.enabled,
-                        protected=stack_def.protected,
+                        force=stack_def.name in self.force_stacks
                     )
                 stacks.append(stack)
             self._stacks = stacks

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -5,8 +5,8 @@ from builtins import object
 import collections
 import logging
 
-from stacker.config import Config
-from .stack import Stack
+from stacker.config import Config, ExternalStack as ExternalStackModel
+from .stack import ExternalStack, Stack
 
 logger = logging.getLogger(__name__)
 
@@ -137,15 +137,21 @@ class Context(object):
             stacks = []
             definitions = self._get_stack_definitions()
             for stack_def in definitions:
-                stack = Stack(
-                    definition=stack_def,
-                    context=self,
-                    mappings=self.mappings,
-                    force=stack_def.name in self.force_stacks,
-                    locked=stack_def.locked,
-                    enabled=stack_def.enabled,
-                    protected=stack_def.protected,
-                )
+                if isinstance(stack_def, ExternalStackModel):
+                    stack = ExternalStack(
+                        definition=stack_def,
+                        context=self
+                    )
+                else:
+                    stack = Stack(
+                        definition=stack_def,
+                        context=self,
+                        mappings=self.mappings,
+                        force=stack_def.name in self.force_stacks,
+                        locked=stack_def.locked,
+                        enabled=stack_def.enabled,
+                        protected=stack_def.protected,
+                    )
                 stacks.append(stack)
             self._stacks = stacks
         return self._stacks

--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -21,8 +21,8 @@ def get_session(region, profile=None):
     """Creates a boto3 session with a cache
 
     Args:
-        region (str): The region for the session
-        profile (str): The profile for the session
+        region (str, optional): The region for the session
+        profile (str, optional): The profile for the session
 
     Returns:
         :class:`boto3.session.Session`: A boto3 session with

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -65,19 +65,18 @@ class Stack(object):
 
     """
 
-    def __init__(self, definition, context, variables=None, mappings=None,
-                 locked=False, force=False, enabled=True, protected=False):
+    def __init__(self, definition, context, mappings=None, force=False):
         self.name = definition.name
         self.fqn = context.get_fqn(definition.stack_name or self.name)
         self.region = definition.region
         self.profile = definition.profile
+        self.locked = definition.locked
+        self.enabled = definition.enabled
+        self.protected = definition.protected
         self.definition = definition
         self.variables = _gather_variables(definition)
         self.mappings = mappings
-        self.locked = locked
         self.force = force
-        self.enabled = enabled
-        self.protected = protected
         self.context = context
         self.outputs = None
 

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -192,3 +192,53 @@ class Stack(object):
 
     def set_outputs(self, outputs):
         self.outputs = outputs
+
+
+class ExternalStack(Stack):
+    """Represents gathered information about an existing external stack
+
+    Args:
+        definition (:class:`stacker.config.Stack`): A stack definition.
+        context (:class:`stacker.context.Context`): Current context for
+            building the stack.
+
+    """
+
+    def __init__(self, definition, context):
+        self.name = definition.name
+        self.fqn = definition.stack_name
+        self.region = definition.region
+        self.profile = definition.profile
+        self.definition = definition
+        self.context = context
+        self.outputs = None
+
+    @property
+    def requires(self):
+        return set()
+
+    @property
+    def stack_policy(self):
+        return None
+
+    @property
+    def blueprint(self):
+        return None
+
+    @property
+    def tags(self):
+        return dict()
+
+    @property
+    def parameter_values(self):
+        return dict()
+
+    @property
+    def required_parameter_definitions(self):
+        return dict()
+
+    def resolve(self, context, provider):
+        pass
+
+    def set_outputs(self, outputs):
+        self.outputs = outputs

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -198,7 +198,7 @@ class ExternalStack(Stack):
     """Represents gathered information about an existing external stack
 
     Args:
-        definition (:class:`stacker.config.Stack`): A stack definition.
+        definition (:class:`stacker.config.ExternalStack`): A stack definition.
         context (:class:`stacker.context.Context`): Current context for
             building the stack.
 
@@ -206,7 +206,8 @@ class ExternalStack(Stack):
 
     def __init__(self, definition, context):
         self.name = definition.name
-        self.fqn = definition.stack_name
+        stack_name = definition.stack_name or self.name
+        self.fqn = definition.fqn or context.get_fqn(stack_name)
         self.region = definition.region
         self.profile = definition.profile
         self.definition = definition

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import object
 import copy
+import logging
 
 from . import util
 from .variables import (
@@ -16,6 +17,8 @@ from .lookups.handlers.output import (
 
 from .blueprints.raw import RawTemplateBlueprint
 from .exceptions import FailedVariableLookup
+
+logger = logging.getLogger(__name__)
 
 
 def _gather_variables(stack_def):
@@ -33,13 +36,15 @@ def _gather_variables(stack_def):
         - variable defined within the stack definition
 
     Args:
-        stack_def (dict): The stack definition being worked on.
+        stack_def (:class:`stacker.config.Stack`): The stack definition being
+            worked on.
 
     Returns:
-        dict: Contains key/value pairs of the collected variables.
+        :obj:`list` of :class:`stacker.variables.Variable`: Contains key/value
+            pairs of the collected  variables.
 
     Raises:
-        AttributeError: Raised when the stack definitition contains an invalid
+        AttributeError: Raised when the stack definition contains an invalid
             attribute. Currently only when using old parameters, rather than
             variables.
     """
@@ -48,18 +53,15 @@ def _gather_variables(stack_def):
 
 
 class Stack(object):
-
     """Represents gathered information about a stack to be built/updated.
 
     Args:
         definition (:class:`stacker.config.Stack`): A stack definition.
         context (:class:`stacker.context.Context`): Current context for
             building the stack.
-        mappings (dict, optional): Cloudformation mappings passed to the
+        mappings (dict, optional): CloudFormation mappings passed to the
             blueprint.
-        locked (bool, optional): Whether or not the stack is locked.
         force (bool, optional): Whether to force updates on this stack.
-        enabled (bool, optional): Whether this stack is enabled
 
     """
 
@@ -193,6 +195,38 @@ class Stack(object):
     def set_outputs(self, outputs):
         self.outputs = outputs
 
+    def should_submit(self):
+        """Tests whether this stack should be submitted to CF
+
+        Returns:
+            bool: If the stack should be submitted, return True.
+
+        """
+
+        if self.enabled:
+            return True
+
+        logger.debug("Stack %s is not enabled.  Skipping.", self.name)
+        return False
+
+    def should_update(self):
+        """Tests whether this stack should be submitted for updates to CF.
+
+        Returns:
+            bool: If the stack should be updated, return True.
+
+        """
+
+        if self.locked:
+            if not self.force:
+                logger.debug("Stack %s locked and not in --force list. "
+                             "Refusing to update.", self.name)
+                return False
+            else:
+                logger.debug("Stack %s locked, but is in --force "
+                             "list.", self.name)
+        return True
+
 
 class ExternalStack(Stack):
     """Represents gathered information about an existing external stack
@@ -243,3 +277,11 @@ class ExternalStack(Stack):
 
     def set_outputs(self, outputs):
         self.outputs = outputs
+
+    def should_submit(self):
+        # Always submit this stack to load outputs
+        return True
+
+    def should_update(self):
+        # Never update an external stack
+        return False

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -144,28 +144,28 @@ class TestBuildAction(unittest.TestCase):
             self.assertEqual(mock_generate_plan().execute.call_count, 1)
 
     def test_should_update(self):
-        test_scenario = namedtuple("test_scenario",
-                                   ["locked", "force", "result"])
         test_scenarios = (
-            test_scenario(locked=False, force=False, result=True),
-            test_scenario(locked=False, force=True, result=True),
-            test_scenario(locked=True, force=False, result=False),
-            test_scenario(locked=True, force=True, result=True)
+            dict(blueprint=None, locked=False, force=False, result=False),
+            dict(blueprint="BLUEPRINT", locked=False, force=False,
+                 result=True),
+            dict(blueprint="BLUEPRINT", locked=False, force=True, result=True),
+            dict(blueprint="BLUEPRINT", locked=True, force=False,
+                 result=False),
+            dict(blueprint="BLUEPRINT", locked=True, force=True, result=True)
         )
-        mock_stack = mock.MagicMock(["locked", "force", "name"])
-        mock_stack.name = "test-stack"
         for t in test_scenarios:
-            mock_stack.locked = t.locked
-            mock_stack.force = t.force
-            self.assertEqual(build.should_update(mock_stack), t.result)
+            mock_stack = mock.MagicMock(
+                ["blueprint", "locked", "force", "name"],
+                name='test-stack', **t)
+            self.assertEqual(build.should_update(mock_stack), t['result'])
 
     def test_should_ensure_cfn_bucket(self):
         test_scenarios = [
-            {"outline": False, "dump": False, "result": True},
-            {"outline": True, "dump": False, "result": False},
-            {"outline": False, "dump": True, "result": False},
-            {"outline": True, "dump": True, "result": False},
-            {"outline": True, "dump": "DUMP", "result": False}
+            dict(outline=False, dump=False, result=True),
+            dict(outline=True, dump=False, result=False),
+            dict(outline=False, dump=True, result=False),
+            dict(outline=True, dump=True, result=False),
+            dict(outline=True, dump="DUMP", result=False)
         ]
 
         for scenario in test_scenarios:
@@ -180,18 +180,17 @@ class TestBuildAction(unittest.TestCase):
                 raise
 
     def test_should_submit(self):
-        test_scenario = namedtuple("test_scenario",
-                                   ["enabled", "result"])
         test_scenarios = (
-            test_scenario(enabled=False, result=False),
-            test_scenario(enabled=True, result=True),
+            dict(blueprint=None, enabled=False, result=True),
+            dict(blueprint="BLUEPRINT", enabled=False,  result=False),
+            dict(blueprint="BLUEPRINT", enabled=True, result=True),
         )
 
-        mock_stack = mock.MagicMock(["enabled", "name"])
-        mock_stack.name = "test-stack"
         for t in test_scenarios:
-            mock_stack.enabled = t.enabled
-            self.assertEqual(build.should_submit(mock_stack), t.result)
+            mock_stack = mock.MagicMock(
+                ["blueprint", "enabled", "name"],
+                name='test-stack', **t)
+            self.assertEqual(build.should_submit(mock_stack), t['result'])
 
 
 class TestLaunchStack(TestBuildAction):

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -3,13 +3,11 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import str
 import unittest
-from collections import namedtuple
 
 import mock
 
 from stacker import exceptions
 from stacker.actions import build
-from stacker.session_cache import get_session
 from stacker.actions.build import (
     _resolve_parameters,
     _handle_missing_parameters,
@@ -19,6 +17,8 @@ from stacker.context import Context, Config
 from stacker.exceptions import StackDidNotChange, StackDoesNotExist
 from stacker.providers.base import BaseProvider
 from stacker.providers.aws.default import Provider
+from stacker.session_cache import get_session
+from stacker.stack import Stack
 from stacker.status import (
     NotSubmittedStatus,
     COMPLETE,
@@ -143,22 +143,6 @@ class TestBuildAction(unittest.TestCase):
             build_action.run(outline=False)
             self.assertEqual(mock_generate_plan().execute.call_count, 1)
 
-    def test_should_update(self):
-        test_scenarios = (
-            dict(blueprint=None, locked=False, force=False, result=False),
-            dict(blueprint="BLUEPRINT", locked=False, force=False,
-                 result=True),
-            dict(blueprint="BLUEPRINT", locked=False, force=True, result=True),
-            dict(blueprint="BLUEPRINT", locked=True, force=False,
-                 result=False),
-            dict(blueprint="BLUEPRINT", locked=True, force=True, result=True)
-        )
-        for t in test_scenarios:
-            mock_stack = mock.MagicMock(
-                ["blueprint", "locked", "force", "name"],
-                name='test-stack', **t)
-            self.assertEqual(build.should_update(mock_stack), t['result'])
-
     def test_should_ensure_cfn_bucket(self):
         test_scenarios = [
             dict(outline=False, dump=False, result=True),
@@ -179,63 +163,91 @@ class TestBuildAction(unittest.TestCase):
                 e.args += ("scenario", str(scenario))
                 raise
 
-    def test_should_submit(self):
-        test_scenarios = (
-            dict(blueprint=None, enabled=False, result=True),
-            dict(blueprint="BLUEPRINT", enabled=False,  result=False),
-            dict(blueprint="BLUEPRINT", enabled=True, result=True),
-        )
 
-        for t in test_scenarios:
-            mock_stack = mock.MagicMock(
-                ["blueprint", "enabled", "name"],
-                name='test-stack', **t)
-            self.assertEqual(build.should_submit(mock_stack), t['result'])
+class TestStack(Stack):
+    def __init__(self, name, context):
+        self.name = name
+        self.fqn = name
+        self.region = None
+        self.profile = None
+        self.locked = False
+        self.enabled = True
+        self.protected = False
+        self.variables = {}
+        self.mappings = {}
+        self.force = False
+        self.context = context
+        self.outputs = None
+
+    @property
+    def requires(self):
+        return set()
+
+    @property
+    def blueprint(self):
+        return mock.MagicMock(rendered='{}')
+
+    @property
+    def stack_policy(self):
+        return None
+
+    @property
+    def tags(self):
+        return {}
+
+    @property
+    def parameter_values(self):
+        return {}
+
+    @property
+    def required_parameter_definitions(self):
+        return {}
+
+    def resolve(self, context, provider):
+        pass
 
 
 class TestLaunchStack(TestBuildAction):
+    def _patch_object(self, *args, **kwargs):
+        m = mock.patch.object(*args, **kwargs)
+        self.addCleanup(m.stop)
+        m.start()
+        return m
+
+    def _get_stack(self, name, *args, **kwargs):
+        if name != self.stack.name or not self.stack_status:
+            raise StackDoesNotExist(name)
+
+        return {'StackName': self.stack.name,
+                'StackStatus': self.stack_status,
+                'Outputs': [],
+                'Tags': []}
+
+    def _make_provider(self):
+        provider = Provider(self.session, interactive=False,
+                            recreate_failed=False)
+        self._patch_object(provider, 'get_stack', side_effect=self._get_stack)
+        self._patch_object(provider, 'update_stack')
+        self._patch_object(provider, 'create_stack')
+        self._patch_object(provider, 'destroy_stack')
+        return provider
+
     def setUp(self):
         self.context = self._get_context()
         self.session = get_session(region=None)
-        self.provider = Provider(self.session, interactive=False,
-                                 recreate_failed=False)
+        self.provider = self._make_provider()
         provider_builder = MockProviderBuilder(self.provider)
         self.build_action = build.Action(self.context,
                                          provider_builder=provider_builder,
                                          cancel=MockThreadingEvent())
+        self._patch_object(self.build_action, "s3_stack_push")
 
-        self.stack = mock.MagicMock()
-        self.stack.region = None
-        self.stack.name = 'vpc'
-        self.stack.fqn = 'vpc'
-        self.stack.blueprint.rendered = '{}'
-        self.stack.locked = False
+        self.stack = TestStack("vpc", self.context)
         self.stack_status = None
 
         plan = self.build_action._generate_plan()
         self.step = plan.steps[0]
         self.step.stack = self.stack
-
-        def patch_object(*args, **kwargs):
-            m = mock.patch.object(*args, **kwargs)
-            self.addCleanup(m.stop)
-            m.start()
-
-        def get_stack(name, *args, **kwargs):
-            if name != self.stack.name or not self.stack_status:
-                raise StackDoesNotExist(name)
-
-            return {'StackName': self.stack.name,
-                    'StackStatus': self.stack_status,
-                    'Outputs': [],
-                    'Tags': []}
-
-        patch_object(self.provider, 'get_stack', side_effect=get_stack)
-        patch_object(self.provider, 'update_stack')
-        patch_object(self.provider, 'create_stack')
-        patch_object(self.provider, 'destroy_stack')
-
-        patch_object(self.build_action, "s3_stack_push")
 
     def _advance(self, new_provider_status, expected_status, expected_reason):
         self.stack_status = new_provider_status

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -5,7 +5,7 @@ from builtins import object
 from mock import MagicMock
 
 from stacker.context import Context
-from stacker.config import Config, Stack
+from stacker.config import Config, Stack, ExternalStack
 from stacker.lookups import Lookup
 
 
@@ -48,6 +48,15 @@ def generate_definition(base_name, stack_id, **overrides):
     }
     definition.update(overrides)
     return Stack(definition)
+
+
+def generate_external_definition(base_name, stack_id, **overrides):
+    definition = {
+        "name": "%s.%d" % (base_name, stack_id),
+        "external": True,
+    }
+    definition.update(overrides)
+    return ExternalStack(definition)
 
 
 def mock_lookup(lookup_input, lookup_type, raw=None):

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -157,8 +157,10 @@ class Dummy(Blueprint):
     }
 
     def create_template(self):
+        input = self.get_variables()["StringVariable"]
         self.template.add_resource(WaitConditionHandle("Dummy"))
         self.template.add_output(Output("DummyId", Value="dummy-1234"))
+        self.template.add_output(Output("StringOutput", Value=input))
         self.template.add_output(Output("Region", Value=Ref("AWS::Region")))
 
 

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -13,7 +13,7 @@ from stacker.config import (
     dump,
     process_remote_sources
 )
-from stacker.config import Config, Stack
+from stacker.config import Config, ExternalStack, Stack
 from stacker.environment import parse_environment
 from stacker import exceptions
 from stacker.lookups.registry import LOOKUP_HANDLERS
@@ -199,6 +199,44 @@ stacks: []
             "'parameters', rather than 'variables'. You are required to update"
             " your config. See https://stacker.readthedocs.io/en/latest/c"
             "onfig.html#variables for additional information.")
+
+    def test_parse_external(self):
+        config = parse("""
+        namespace: prod
+        stacks:
+        - name: vpc
+          stack_name: cool-vpc
+          class_path: blueprints.VPC
+          parameters:
+            Foo: bar
+        - name: external-vpc
+          stack_name: other-cool-vpc
+          external: yes
+        """)
+
+        local_stack, external_stack = config.stacks
+        self.assertIsInstance(local_stack, Stack)
+        self.assertEquals(local_stack.name, 'vpc')
+        self.assertEquals(local_stack.stack_name, 'cool-vpc')
+        self.assertIsInstance(external_stack, ExternalStack)
+        self.assertEquals(external_stack.name, 'external-vpc')
+        self.assertEquals(external_stack.stack_name, 'other-cool-vpc')
+
+    def test_parse_external_invalid(self):
+        config = parse("""
+        namespace: prod
+        stacks:
+        - name: vpc
+          class_path: blueprints.VPC
+          parameters:
+            Foo: bar
+        - name: external-vpc
+          stack_name: some-other-vpc
+          external: yes
+        """)
+
+        with self.assertRaises(exceptions.InvalidConfig):
+            config.validate()
 
     def test_config_build(self):
         vpc = Stack({"name": "vpc", "class_path": "blueprints.VPC"})
@@ -422,22 +460,28 @@ stacks: []
                 Stack({
                     "name": "bastion",
                     "class_path": "blueprints.Bastion",
-                    "requires": ["vpc"]})]})
+                    "requires": ["vpc"]}),
+                ExternalStack({
+                    "name": "external"})]})
 
         self.assertEqual(dump(config), b"""namespace: prod
 stacks:
 - class_path: blueprints.VPC
   enabled: true
+  external: false
   locked: false
   name: vpc
   protected: false
 - class_path: blueprints.Bastion
   enabled: true
+  external: false
   locked: false
   name: bastion
   protected: false
   requires:
   - vpc
+- external: true
+  name: external
 """)
 
     def test_load_register_custom_lookups(self):

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -6,8 +6,8 @@ import unittest
 
 from stacker.context import Context
 from stacker.config import Config
-from stacker.stack import Stack
-from .factories import generate_definition
+from stacker.stack import Stack, ExternalStack
+from .factories import generate_definition, generate_external_definition
 
 
 class TestStack(unittest.TestCase):
@@ -104,6 +104,46 @@ class TestStack(unittest.TestCase):
         )
         stack = Stack(definition=definition, context=self.context)
         self.assertEquals(stack.tags, {"environment": "prod", "app": "graph"})
+
+    def test_stack_should_update(self):
+        test_scenarios = [
+            dict(locked=False, force=False, result=True),
+            dict(locked=False, force=True, result=True),
+            dict(locked=True, force=False, result=False),
+            dict(locked=True, force=True, result=True)
+        ]
+
+        for t in test_scenarios:
+            definition = generate_definition(
+                base_name="vpc",
+                stack_id=1,
+                locked=t['locked'])
+            stack = Stack(definition=definition, context=self.context,
+                          force=t['force'])
+            self.assertEqual(stack.should_update(), t['result'])
+
+    def test_stack_should_submit(self):
+        for enabled in (True, False):
+            definition = generate_definition(
+                base_name="vpc",
+                stack_id=1,
+                enabled=enabled)
+            stack = Stack(definition=definition, context=self.context)
+            self.assertEqual(stack.should_submit(), enabled)
+
+    def test_external_stack_should_update(self):
+        definition = generate_external_definition(
+            base_name="vpc",
+            stack_id=1)
+        stack = ExternalStack(definition=definition, context=self.context)
+        self.assertEqual(stack.should_update(), False)
+
+    def test_external_stack_should_submit(self):
+        definition = generate_external_definition(
+            base_name="vpc",
+            stack_id=1)
+        stack = ExternalStack(definition=definition, context=self.context)
+        self.assertEqual(stack.should_submit(), True)
 
 
 if __name__ == '__main__':

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -129,16 +129,10 @@ class TestUtil(unittest.TestCase):
             self.assertEqual(get_client_region(client), region)
 
     def test_get_s3_endpoint(self):
-        endpoint_map = {
-            "us-east-1": "https://s3.amazonaws.com",
-            "us-west-1": "https://s3.us-west-1.amazonaws.com",
-            "eu-west-1": "https://s3.eu-west-1.amazonaws.com",
-            "sa-east-1": "https://s3.sa-east-1.amazonaws.com",
-        }
-
-        for region in endpoint_map:
-            client = boto3.client("s3", region_name=region)
-            self.assertEqual(get_s3_endpoint(client), endpoint_map[region])
+        endpoint_url = "https://example.com"
+        client = boto3.client("s3", region_name="us-east-1",
+                              endpoint_url=endpoint_url)
+        self.assertEqual(get_s3_endpoint(client), endpoint_url)
 
     def test_s3_bucket_location_constraint(self):
         tests = (

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -162,7 +162,7 @@ namespace: ${STACKER_NAMESPACE}
 stacks:
   - name: vpc
     class_path: stacker.tests.fixtures.mock_blueprints.VPC
-    stack_policy: tests/fixtures/stack_policies/default.json
+    stack_policy_path: fixtures/stack_policies/default.json
     variables:
       PublicSubnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
       PrivateSubnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22
@@ -468,7 +468,7 @@ stacks:
 EOF
   }
 
-config2() {
+  config2() {
     cat <<EOF
 namespace: ${STACKER_NAMESPACE}
 stacks:
@@ -1062,4 +1062,75 @@ EOF
   assert_has_line "Using default AWS provider mode"
   assert_has_line "vpc: submitted (creating new stack)"
   assert_has_line "vpc: complete (creating new stack)"
+}
+
+@test "stacker build - external stack" {
+  needs_aws
+
+  config1() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc/west
+    stack_name: external-vpc
+    profile: stacker
+    region: us-west-1
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: vpc/east
+    stack_name: external-vpc
+    profile: stacker
+    region: us-east-1
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+EOF
+  }
+
+  config2() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc/west
+    stack_name: external-vpc
+    profile: stacker
+    region: us-west-1
+    external: yes
+  - name: vpc/east
+    fqn: ${STACKER_NAMESPACE}-external-vpc
+    profile: stacker
+    region: us-east-1
+    external: yes
+  - name: vpc/combo
+    stack_name: vpc
+    profile: stacker
+    region: us-east-1
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    variables:
+      StringVariable: >-
+        \${output vpc/west::Region}
+        \${output vpc/east::Region}
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config2)
+    stacker destroy --force <(config1)
+  }
+
+  # Create the new stacks.
+  stacker build <(config1)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "vpc/west: submitted (creating new stack)"
+  assert_has_line "vpc/west: complete (creating new stack)"
+  assert_has_line "vpc/east: submitted (creating new stack)"
+  assert_has_line "vpc/east: complete (creating new stack)"
+
+  stacker build <(config2)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "vpc/combo: submitted (creating new stack)"
+  assert_has_line "vpc/combo: complete (creating new stack)"
+
+  stacker info <(config2)
+  assert_has_line "StringOutput: us-west-1 us-east-1"
+
 }


### PR DESCRIPTION
Currently, the `ref` and `xref` lookups always use the same AWS profile and region that Stacker is initialized with. That means they cannot access outputs in other accounts or regions. It is possible to create a stack that will just "pull" those outputs by adding `locked: true` to it. But that still does not make it possible to reference a stack outside of the current namespace, if one is configured. Additionally, options that should never take effect for a "read-only" stack were allowed, such as `class_path` or `stack_policy_path`.

To handle that use case, introduce and document the `external: yes` option for stacks. External stacks do not have any of the options related to creating or updating resources, such as `class_path` and `template_path`, and are used only as sources of values to other stacks (through outputs and lookups).
Additionally, add an `fqn` option to external stacks to fix the namespace issue.

# Internal changes

To ensure the separation has the desired effect, enable `strict` mode while parsing configuration into models, but *only* for non-top-level keys. Achieve it by manually filtering unrecognized top-level keys before forwarding the data for parsing.

To better separate external and managed stacks in config, rework the model hierarchy a little: add `BaseStack` that only contains the shared config options between both stack types, make it a superclass of `Stack`, and introduce `ExternalStack`. Unfortunately Schematics 2.0 has a bug where it did not validate models parsed using polymorphism, so upgrade to version 2.1.

Move decisions on whether a stack needs to be submitted or updated to the `stacker.stack.Stack` class, to simply the logic and allow it to differ between external and managed stacks. Introduce `stacker.stack.ExternalStack` with "empty" implementations of all the methods/properties related to templates, blueprints and updates.

# Documentation updates

Rework the Stack documentation to list options allowed for all stacks, external and managed stacks separately. Document everything in YAML format, so that people can copy snippets to their configs from the different parts. Fix some typos and clarify some details in the process.

# Open questions

The `external/managed` terminology is the best I could come up with, but I still feel it can be improved. Any suggestions of alternatives are welcome!

# Notes

I ran functional tests manually on my all account and they passed - I even had to fix one that had `stack_policy_path` misspelled and was no longer accepted due to strict parsing.
