### PR TITLE
Add --only flag to build command

### DIFF
--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -34,6 +34,9 @@ class Build(BaseCommand):
                                  "dependencies. Can be specified more than "
                                  "once. If not specified then stacker will "
                                  "work on all stacks in the config file.")
+        parser.add_argument("--only", action="store_true",
+                            help="Lock all stacks, other than those provided "
+                                 "in the --stacks flag.")
         parser.add_argument("-j", "--max-parallel", action="store", type=int,
                             default=0,
                             help="The maximum number of stacks to execute in "
@@ -58,4 +61,7 @@ class Build(BaseCommand):
                        dump=options.dump)
 
     def get_context_kwargs(self, options, **kwargs):
-        return {"stack_names": options.stacks, "force_stacks": options.force}
+        return {
+            "stack_names": options.stacks,
+            "force_stacks": options.force,
+            "only_specified": options.only}

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -84,6 +84,12 @@ class Stack(object):
 
     @property
     def requires(self):
+        # By definition, a locked stack has no dependencies, because we won't
+        # be performing an update operation on the stack. This means, resolving
+        # outputs from dependencies is unnecessary.
+        if self.locked:
+            return []
+
         requires = set(self.definition.requires or [])
 
         # Add any dependencies based on output lookups

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -35,6 +35,14 @@ class TestContext(unittest.TestCase):
         self.assertEqual(stack_names[0], "namespace-stack1")
         self.assertEqual(stack_names[1], "namespace-stack2")
 
+    def test_context_get_stacks_only_specified(self):
+        context = Context(config=self.config,
+                          stack_names=["stack1"],
+                          only_specified=True)
+        stacks = context.get_stacks_dict()
+        self.assertFalse(stacks["namespace-stack1"].locked)
+        self.assertTrue(stacks["namespace-stack2"].locked)
+
     def test_context_get_fqn(self):
         context = Context(config=self.config)
         fqn = context.get_fqn()

--- a/tests/test_suite/34_stacker_build-only.bats
+++ b/tests/test_suite/34_stacker_build-only.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+
+@test "stacker build - only" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: db
+    requires: [vpc]
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: app
+    requires: [db]
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+
+  stacker build --only --stacks app <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "db: skipped (locked)"
+  assert_has_line "app: skipped (nochange)"
+  assert_has_line -v "vpc"
+}


### PR DESCRIPTION
This adds an `--only` flag to `stacker build`, which, when used in combination with the `--stacks` flag, can make it easier for workflows where you want to work on a single stack, without effecting dependencies.

Take the following example. Let's say we have a graph like this:

```
app -> cluster -> vpc
```

If we want to work on the `app` stack, we can specify `--stacks app`, and stacker will filter the graph so that only `app` and it's transitive dependencies are operated in. However, this has some disadvantages:

1. If `cluster` is currently undergoing a change, `stacker build` will fail.
2. stacker works through the entire dependency graph, trying to update all transitive dependencies.

With the addition of the `--only` flag, all stacks other than those explicitly specified with `--stacks` are marked as `locked`. This means that you can operate on only the `app` stack, without worry about what state that transitive dependencies are in.