### PR TITLE
allow configs without stacks

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -413,6 +413,8 @@ class Action(BaseAction):
 
         """
         plan = self._generate_plan(tail=tail)
+        if not plan.keys():
+            logger.warn('WARNING: No stacks detected (error in config?)')
         if not outline and not dump:
             plan.outline(logging.DEBUG)
             logger.debug("Launching stacks: %s", ", ".join(plan.keys()))

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -90,6 +90,8 @@ class Action(BaseAction):
 
     def run(self, force, concurrency=0, tail=False, *args, **kwargs):
         plan = self._generate_plan(tail=tail)
+        if not plan.keys():
+            logger.warn('WARNING: No stacks detected (error in config?)')
         if force:
             # need to generate a new plan to log since the outline sets the
             # steps to COMPLETE in order to log them

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -278,7 +278,10 @@ class Action(build.Action):
     def run(self, concurrency=0, *args, **kwargs):
         plan = self._generate_plan()
         plan.outline(logging.DEBUG)
-        logger.info("Diffing stacks: %s", ", ".join(plan.keys()))
+        if plan.keys():
+            logger.info("Diffing stacks: %s", ", ".join(plan.keys()))
+        else:
+            logger.warn('WARNING: No stacks detected (error in config?)')
         walker = build_walker(concurrency)
         plan.execute(walker)
 

--- a/stacker/actions/info.py
+++ b/stacker/actions/info.py
@@ -18,6 +18,8 @@ class Action(BaseAction):
 
     def run(self, *args, **kwargs):
         logger.info('Outputs for stacks: %s', self.context.get_fqn())
+        if not self.context.get_stacks():
+            logger.warn('WARNING: No stacks detected (error in config?)')
         for stack in self.context.get_stacks():
             provider = self.build_provider(stack)
 

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -402,7 +402,7 @@ class Config(Model):
     lookups = DictType(StringType, serialize_when_none=False)
 
     stacks = ListType(
-        ModelType(Stack), default=[], validators=[not_empty_list])
+        ModelType(Stack), default=[])
 
     def _remove_excess_keys(self, data):
         excess_keys = set(data.keys())

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -94,16 +94,6 @@ class TestConfig(unittest.TestCase):
             stack_errors['class_path'][0].__str__(),
             "template_path cannot be present when class_path is provided.")
 
-    def test_config_validate_no_stacks(self):
-        config = Config({"namespace": "prod"})
-        with self.assertRaises(exceptions.InvalidConfig) as ex:
-            config.validate()
-
-        error = ex.exception.errors['stacks'].errors[0]
-        self.assertEquals(
-            error.__str__(),
-            "Should have more than one element.")
-
     def test_config_validate_missing_name(self):
         config = Config({
             "namespace": "prod",

--- a/tests/test_suite/03_stacker_build-config_with_no_stacks.bats
+++ b/tests/test_suite/03_stacker_build-config_with_no_stacks.bats
@@ -7,5 +7,5 @@ load ../test_helper
 namespace: ${STACKER_NAMESPACE}
 EOF
   assert ! "$status" -eq 0
-  assert_has_line 'Should have more than one element'
+  assert_has_line 'WARNING: No stacks detected'
 }


### PR DESCRIPTION
This relaxes the current stack validation, replacing it instead with
action warning messages.

With this, configurations can be created with only hooks.