### PR TITLE
add missing config keys to s3 package source model

### DIFF
--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -258,6 +258,10 @@ class S3PackageSource(Model):
 
     requester_pays = BooleanType(serialize_when_none=False)
 
+    paths = ListType(StringType, serialize_when_none=False)
+
+    configs = ListType(StringType, serialize_when_none=False)
+
 
 class PackageSources(Model):
     git = ListType(ModelType(GitPackageSource))

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -236,6 +236,10 @@ stacks: []
             - bucket: anotherexamplebucket
               key: example-blueprints-v3.tar.gz
               use_latest: false
+              paths:
+                - foo
+              configs:
+                - foo/config.yml
           git:
             - uri: git@github.com:acmecorp/stacker_blueprints.git
             - uri: git@github.com:remind101/stacker_blueprints.git
@@ -246,6 +250,10 @@ stacks: []
               branch: staging
             - uri: git@github.com:contoso/foo.git
               commit: 12345678
+              paths:
+                - bar
+              configs:
+                - bar/moreconfig.yml
         tags:
           environment: production
         stacks:
@@ -301,6 +309,10 @@ stacks: []
             - bucket: anotherexamplebucket
               key: example-blueprints-v3.tar.gz
               use_latest: false
+              paths:
+                - foo
+              configs:
+                - foo/config.yml
           git:
             - uri: git@github.com:acmecorp/stacker_blueprints.git
             - uri: git@github.com:remind101/stacker_blueprints.git
@@ -311,6 +323,10 @@ stacks: []
               branch: staging
             - uri: git@github.com:contoso/foo.git
               commit: 12345678
+              paths:
+                - bar
+              configs:
+                - bar/moreconfig.yml
         tags:
           environment: production
         stacks:


### PR DESCRIPTION
This fixes a regression in 1.4 - now that the keys are being validated, the model needs these missing options to prevent an InvalidConfig exception.