### PR TITLE
Fix file lookup documented and actual return types

### DIFF
--- a/stacker/lookups/handlers/file.py
+++ b/stacker/lookups/handlers/file.py
@@ -136,7 +136,7 @@ def _parameterize_string(raw):
         s_index = match.end()
 
     if not parts:
-        return raw
+        return GenericHelperFn(raw)
 
     parts.append(raw[s_index:])
     return GenericHelperFn({u"Fn::Join": [u"", parts]})
@@ -152,7 +152,7 @@ def parameterized_codec(raw, b64):
             call
 
     Returns:
-        :class:`troposphere.GenericHelperFn`: output to be included in a
+        :class:`troposphere.AWSHelperFn`: output to be included in a
         CloudFormation template.
     """
 

--- a/stacker/tests/lookups/handlers/test_file.py
+++ b/stacker/tests/lookups/handlers/test_file.py
@@ -9,7 +9,7 @@ import mock
 import base64
 import yaml
 import json
-from troposphere import Base64, Join
+from troposphere import Base64, GenericHelperFn, Join
 
 from stacker.lookups.handlers.file import (json_codec, handler,
                                            parameterized_codec, yaml_codec)
@@ -46,12 +46,21 @@ class TestFileTranslator(unittest.TestCase):
         )
 
         out = parameterized_codec(u'Test {{Interpolation}} Here', True)
+        self.assertEqual(Base64, out.__class__)
         self.assertTemplateEqual(expected, out)
 
     def test_parameterized_codec_plain(self):
         expected = Join(u'', [u'Test ', {u'Ref': u'Interpolation'}, u' Here'])
 
         out = parameterized_codec(u'Test {{Interpolation}} Here', False)
+        self.assertEqual(GenericHelperFn, out.__class__)
+        self.assertTemplateEqual(expected, out)
+
+    def test_parameterized_codec_plain_no_interpolation(self):
+        expected = u'Test Without Interpolation Here'
+
+        out = parameterized_codec(u'Test Without Interpolation Here', False)
+        self.assertEqual(GenericHelperFn, out.__class__)
         self.assertTemplateEqual(expected, out)
 
     def test_yaml_codec_raw(self):


### PR DESCRIPTION
Previously, file was reported to return `GenericHelperFn`, when it in fact would return either `GenericHelperFn` or `Base64`. Updated the docstring to reflect their common base class instead.

Also updated the function to fix a regression where a string was sometimes being returned instead.

Fixes #645