### PR TITLE
update git ref to explicitly return string (fix py3 bytes error)

### DIFF
--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -252,7 +252,7 @@ Outputs:
                     GitPackageSource({'uri': 'https://github.com/remind101/'
                                              'stacker.git',
                                       'branch': 'release-1.0'})),
-                b'857b4834980e582874d70feef77bb064b60762d1'
+                '857b4834980e582874d70feef77bb064b60762d1'
             )
             self.assertEqual(
                 sp.determine_git_ref(

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -877,6 +877,8 @@ class SourceProcessor(object):
                 config['uri'],
                 self.determine_git_ls_remote_ref(config)
             )
+        if sys.version_info[0] > 2 and isinstance(ref, bytes):
+            return ref.decode()
         return ref
 
     def sanitize_uri_path(self, uri):


### PR DESCRIPTION
The PyGit integration is broken on py3 without this change -- the bytes passed [here](https://github.com/gitpython-developers/GitPython/blob/2.1.11/git/refs/symbolic.py#L278-L311) cause it to raise a ValueError.