### PR TITLE
Version dependencies format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ install_requires = [
     ##
     "PyYAML>=3.12",
     "awacs>=0.6.0",
-    "gitpython~=2.0",
-    "schematics~=2.0.1",
+    "gitpython>=2.0,<3.0",
+    "schematics>=2.0.1,<2.1.0",
     "formic2",
-    "python-dateutil~=2.0",
+    "python-dateutil>=2.0,<3.0",
 ]
 
 tests_require = [


### PR DESCRIPTION
Specify version dependencies as documented in
https://docs.python.org/3.6/distutils/setupscript.html#relationships-between-distributions-and-packages.
Using the '~=' format causes OS packages built with fpm to have a wrong
dependency.

(note the '=2.0' instead of '~=2.0')
```The following packages have unmet dependencies:
 python3-stacker : Depends: python3-gitpython (= 2.0) but 2.1.11-15 is 
to be installed
                   Depends: python3-schematics (= 2.0.1) but 2.0.1-15 is 
to be installed
                   Depends: python3-dateutil (= 2.0) but 2.7.3-15 is to 
be installed```