### PR TITLE
Roles must be comma seperated list, as stated in templates/stacker-bu…

### DIFF
--- a/examples/cross-account/stacker.yaml
+++ b/examples/cross-account/stacker.yaml
@@ -14,7 +14,5 @@ stacks:
     profile: master
     template_path: templates/stacker-bucket.yaml
     variables:
-      Roles:
-        # Change these to the correct AWS account IDs
-        - arn:aws:iam::<prod account id>:role/Stacker
-        - arn:aws:iam::<stage account id>:role/Stacker
+      # Change these to the correct AWS account IDs, must be comma seperated list
+      Roles: arn:aws:iam::<prod account id>:role/Stacker, arn:aws:iam::<stage account id>:role/Stacker


### PR DESCRIPTION
I encountered this inconsistency while trying the cross-account example. The stacker.yaml states an array of accounts, while the corresponding template  templates/stacker-bucket.yaml clearly states it should be given a comma seperated list.