### PR TITLE
fix interactive_update_stack calls with empty string parameters

### DIFF
--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -851,7 +851,7 @@ class Provider(BaseProvider):
         old_parameters_as_dict = self.params_as_dict(old_parameters)
         new_parameters_as_dict = self.params_as_dict(
             [x
-             if x.get('ParameterValue')
+             if 'ParameterValue' in x
              else {'ParameterKey': x['ParameterKey'],
                    'ParameterValue': old_parameters_as_dict[x['ParameterKey']]}
              for x in parameters]


### PR DESCRIPTION
PR #644 didn't account for empty string parameters