### PR TITLE
Locked stacks have no dependencies

### DIFF
--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -89,6 +89,12 @@ class Stack(object):
 
     @property
     def requires(self):
+        # By definition, a locked stack has no dependencies, because we won't
+        # be performing an update operation on the stack. This means, resolving
+        # outputs from dependencies is unnecessary.
+        if self.locked and not self.force:
+            return []
+
         requires = set(self.definition.requires or [])
 
         # Add any dependencies based on output lookups

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -47,6 +47,32 @@ class TestStack(unittest.TestCase):
             stack.requires,
         )
 
+    def test_stack_requires_when_locked(self):
+        definition = generate_definition(
+            base_name="vpc",
+            stack_id=1,
+            variables={
+                "Var1": "${noop fakeStack3::FakeOutput}",
+                "Var2": (
+                    "some.template.value:${output fakeStack2::FakeOutput}:"
+                    "${output fakeStack::FakeOutput}"
+                ),
+                "Var3": "${output fakeStack::FakeOutput},"
+                        "${output fakeStack2::FakeOutput}",
+            },
+            requires=["fakeStack"],
+        )
+        stack = Stack(definition=definition, context=self.context)
+
+        stack.locked = True
+        self.assertEqual(len(stack.requires), 0)
+
+        # TODO(ejholmes): When the stack is in `--force`, it's not really
+        # locked. Maybe it would be better if `stack.locked` were false when
+        # the stack is in `--force`.
+        stack.force = True
+        self.assertEqual(len(stack.requires), 2)
+
     def test_stack_requires_circular_ref(self):
         definition = generate_definition(
             base_name="vpc",


### PR DESCRIPTION
This is a performance optimization when using the `--stacks/--targets` flag, and extracted from https://github.com/cloudtools/stacker/pull/632.

Think of the following example

```yaml
stacks:
  - name: a
    locked: true
  - name: b
    requires: [a]
    locked: true
  - name: c
    requires: [b]
```

This forms a dependency graph like so:

```
c -> b -> a
```

Given I run `stacker build --targets c`, stacker will walk all 3 nodes in the graph, however, given that `b` is locked, it's unnecessary for stacker to execute `a`; since `b` is locked it doesn't need any information from `a`, and thus, doesn't actually depend on `a`.

With this change, because `b` is locked, it has no dependencies, so `a` will not be included in the filtered graph, which becomes:

```
c -> b
```