### PR TITLE
Set default AWS profile earlier

### DIFF
--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -30,12 +30,12 @@ class Stacker(BaseCommand):
         else:
             logger.info("Using default AWS provider mode")
 
+        session_cache.default_profile = options.profile
+
         config = load_config(
             options.config.read(),
             environment=options.environment,
             validate=True)
-
-        session_cache.default_profile = options.profile
 
         options.provider_builder = default.ProviderBuilder(
             region=options.region,


### PR DESCRIPTION
This moves where we set [`session_cache.default_profile`](https://github.com/cloudtools/stacker/blob/master/stacker/session_cache.py#L17) to run before we call `load_config`.

Before this change, if you had a custom lookup that made AWS API calls, it would not run under the profile provided via `--profile` on the command line.

This allows any custom lookups that perform initialization to use [`session_cache.get_session`](https://github.com/cloudtools/stacker/blob/63b772f61b5fb9f44f0d2ca124c6265c06d01127/stacker/session_cache.py#L20) and get the expected results when `--profile` was provided on the command line.