### PR TITLE
Fix lint warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
       - checkout
       - run: sudo pip install flake8 codecov pep8-naming flake8-future-import
       - run: sudo python setup.py install
+      - run: flake8 --version
       - run: sudo make lint
 
   unit-test-27:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ build:
 	docker build -t remind101/stacker .
 
 lint:
-	flake8 --require-code --min-version=2.7 --ignore FI50,FI51,FI53,FI14,E402 --exclude stacker/tests/ stacker
-	flake8 --require-code --min-version=2.7 --ignore FI50,FI51,FI53,FI14,E402,N802 stacker/tests # ignore setUp naming
+	flake8 --require-code --min-version=2.7 --ignore FI50,FI51,FI53,FI14,E402,W503,W504,W605 --exclude stacker/tests/ stacker
+	flake8 --require-code --min-version=2.7 --ignore FI50,FI51,FI53,FI14,E402,N802,W605 stacker/tests # ignore setUp naming
 
 test-unit: clean
 	AWS_DEFAULT_REGION=us-east-1 python setup.py nosetests


### PR DESCRIPTION
Newer versions of flake8 have added some new warnings (W503, W504 and W605). They're kinda ridiculous, so I've added them to the list of ignores.