### PR TITLE
unlock versions as moto/issues/1793 is resolved.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,8 @@ src_dir = os.path.dirname(__file__)
 install_requires = [
     "future",
     "troposphere>=1.9.0",
-    # pinning needed till https://github.com/spulec/moto/issues/1793 is
-    # resolved
-    "botocore<1.11.0",
-    "boto3>=1.7.0,<1.8.0",
-    ##
+    "botocore>=1.6.0",
+    "boto3>=1.3.1",
     "PyYAML>=3.12",
     "awacs>=0.6.0",
     "gitpython>=2.0,<3.0",
@@ -23,10 +20,6 @@ install_requires = [
 ]
 
 tests_require = [
-    # pinning needed till https://github.com/spulec/moto/issues/1793 is
-    # resolved
-    "aws-xray-sdk==1.1.2",
-    ##
     "mock~=2.0.0",
     "moto~=1.1.24",
     "testfixtures~=4.10.0",


### PR DESCRIPTION
link: https://github.com/spulec/moto/pull/1907

Don't really know what are the minimal requirements for boto3 and botocore, so I just reset them to the original value.

Hopefully this PR can pass all the tests.  :D


related commits here:

https://github.com/cloudtools/stacker/commit/bf8ae4ed47a8fef2ed03a1b673beaa2aa2c827d6
https://github.com/cloudtools/stacker/commit/6f2cc37cb8ce1e89619a88a24680efef3e054c04
