### PR TITLE
Use default ACL for uploaded lambda code

### DIFF
--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -228,8 +228,7 @@ def _upload_code(s3_conn, bucket, prefix, name, contents, content_hash):
     else:
         logger.info('lambda: uploading object %s', key)
         s3_conn.put_object(Bucket=bucket, Key=key, Body=contents,
-                           ContentType='application/zip',
-                           ACL='authenticated-read')
+                           ContentType='application/zip')
 
     return Code(S3Bucket=bucket, S3Key=key)
 


### PR DESCRIPTION
The "Authenticated-Read" ACL, currently set on all uploads, allows your code
to be read by all S3 users. Default behavior should be to use the permissions
implied by the bucket policy, i.e. "private".

Organizations that do not grant SetObjectAcl permissions (for fear of
data loss) will block this call.