### PR TITLE
Pinning PyYAML to 3.13 to deal with cfn-flip pin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ lint:
 	flake8 --require-code --min-version=2.7 --ignore FI50,FI51,FI53,FI14,E402,N802,W605 stacker/tests # ignore setUp naming
 
 test-unit: clean
-	AWS_DEFAULT_REGION=us-east-1 python setup.py nosetests
+	AWS_ACCESS_KEY_ID=x AWS_SECRET_ACCESS_KEY=x AWS_DEFAULT_REGION=us-east-1 python setup.py nosetests
 
 test-unit3: clean
-	AWS_DEFAULT_REGION=us-east-1 python3 setup.py nosetests
+	AWS_ACCESS_KEY_ID=x AWS_SECRET_ACCESS_KEY=x AWS_DEFAULT_REGION=us-east-1 python3 setup.py nosetests
 
 clean:
 	rm -rf .egg stacker.egg-info

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "troposphere>=1.9.0",
     "botocore>=1.6.0",
     "boto3>=1.3.1",
-    "PyYAML>=3.12",
+    "PyYAML==3.13",
     "awacs>=0.6.0",
     "gitpython>=2.0,<3.0",
     "schematics>=2.0.1,<2.1.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "troposphere>=1.9.0",
     "botocore>=1.6.0",
     "boto3>=1.3.1",
-    "PyYAML==3.13",
+    "PyYAML>=3.13b1",
     "awacs>=0.6.0",
     "gitpython>=2.0,<3.0",
     "schematics>=2.0.1,<2.1.0",

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,10 @@ src_dir = os.path.dirname(__file__)
 install_requires = [
     "future",
     "troposphere>=1.9.0",
-    "botocore>=1.6.0",
-    "boto3>=1.3.1",
+    # pinning needed till https://github.com/spulec/moto/issues/1924 is
+    # resolved
+    "botocore<1.11.0",
+    "boto3>=1.7.0,<1.8.0",
     "PyYAML>=3.13b1",
     "awacs>=0.6.0",
     "gitpython>=2.0,<3.0",
@@ -20,6 +22,9 @@ install_requires = [
 ]
 
 tests_require = [
+    # pinning needed till https://github.com/spulec/moto/issues/1924 is
+    # resolved
+    "aws-xray-sdk==1.1.2",
     "mock~=2.0.0",
     "moto~=1.1.24",
     "testfixtures~=4.10.0",


### PR DESCRIPTION
https://github.com/awslabs/aws-cfn-template-flip/pull/54

YAML was pinned in the cfn-flip package that troposphere depends on, and
without this we have issues with building.