### PR TITLE
add jinja2 template parsing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ Contents:
    lookups
    commands
    blueprints
+   templates
    API Docs <api/modules>
 
 

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1,0 +1,23 @@
+==========
+Templates
+==========
+
+CloudFormation templates can be provided via python Blueprints_ or JSON/YAML.
+JSON/YAML templates are specified for stacks via the ``template_path`` config
+option (see `Stacks <config.html#stacks>`_).
+
+Jinja2 Templating
+=================
+
+Templates with a ``.j2`` extension will be parsed using `Jinja2 
+<http://jinja.pocoo.org/>`_. The stacker ``context`` and ``mappings`` objects
+and stack ``variables`` objects are available for use in the template:
+
+.. code-block:: yaml
+
+    Description: TestTemplate
+    Resources:
+      Bucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketName: {{ context.environment.foo }}-{{ variables.myparamname }}

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     "PyYAML>=3.13b1",
     "awacs>=0.6.0",
     "gitpython>=2.0,<3.0",
+    "jinja2>=2.7,<3.0",
     "schematics>=2.0.1,<2.1.0",
     "formic2",
     "python-dateutil>=2.0,<3.0",

--- a/stacker/tests/blueprints/test_raw.py
+++ b/stacker/tests/blueprints/test_raw.py
@@ -16,6 +16,7 @@ from ..factories import mock_context
 
 RAW_JSON_TEMPLATE_PATH = 'stacker/tests/fixtures/cfn_template.json'
 RAW_YAML_TEMPLATE_PATH = 'stacker/tests/fixtures/cfn_template.yaml'
+RAW_J2_TEMPLATE_PATH = 'stacker/tests/fixtures/cfn_template.json.j2'
 
 
 class TestRawBluePrintHelpers(unittest.TestCase):
@@ -112,6 +113,48 @@ class TestBlueprintRendering(unittest.TestCase):
                 name="test",
                 context=mock_context(),
                 raw_template_path=RAW_JSON_TEMPLATE_PATH).to_json(),
+            expected_json
+        )
+
+    def test_j2_to_json(self):
+        """Verify jinja2 template parsing."""
+        expected_json = json.dumps(
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Description": "TestTemplate",
+                "Parameters": {
+                    "Param1": {
+                        "Type": "String"
+                    },
+                    "Param2": {
+                        "Default": "default",
+                        "Type": "CommaDelimitedList"
+                    }
+                },
+                "Resources": {
+                    "Dummy": {
+                        "Type": "AWS::CloudFormation::WaitConditionHandle"
+                    }
+                },
+                "Outputs": {
+                    "DummyId": {
+                        "Value": "dummy-bar-foo-1234"
+                    }
+                }
+            },
+            sort_keys=True,
+            indent=4
+        )
+        self.assertEqual(
+            RawTemplateBlueprint(
+                name="stack1",
+                context=mock_context(
+                    extra_config_args={'stacks': [{'name': 'stack1',
+                                                   'template_path': 'unused',
+                                                   'variables': {
+                                                       'bar': 'foo'}}]},
+                    environment={'foo': 'bar'}),
+                raw_template_path=RAW_J2_TEMPLATE_PATH).to_json(),
             expected_json
         )
 

--- a/stacker/tests/blueprints/test_raw.py
+++ b/stacker/tests/blueprints/test_raw.py
@@ -12,6 +12,7 @@ from mock import MagicMock
 from stacker.blueprints.raw import (
     get_template_params, get_template_path, RawTemplateBlueprint
 )
+from stacker.variables import Variable
 from ..factories import mock_context
 
 RAW_JSON_TEMPLATE_PATH = 'stacker/tests/fixtures/cfn_template.json'
@@ -138,24 +139,29 @@ class TestBlueprintRendering(unittest.TestCase):
                 },
                 "Outputs": {
                     "DummyId": {
-                        "Value": "dummy-bar-foo-1234"
+                        "Value": "dummy-bar-param1val-foo-1234"
                     }
                 }
             },
             sort_keys=True,
             indent=4
         )
+        blueprint = RawTemplateBlueprint(
+            name="stack1",
+            context=mock_context(
+                extra_config_args={'stacks': [{'name': 'stack1',
+                                               'template_path': 'unused',
+                                               'variables': {
+                                                   'Param1': 'param1val',
+                                                   'bar': 'foo'}}]},
+                environment={'foo': 'bar'}),
+            raw_template_path=RAW_J2_TEMPLATE_PATH
+        )
+        blueprint.resolve_variables([Variable("Param1", "param1val"),
+                                     Variable("bar", "foo")])
         self.assertEqual(
-            RawTemplateBlueprint(
-                name="stack1",
-                context=mock_context(
-                    extra_config_args={'stacks': [{'name': 'stack1',
-                                                   'template_path': 'unused',
-                                                   'variables': {
-                                                       'bar': 'foo'}}]},
-                    environment={'foo': 'bar'}),
-                raw_template_path=RAW_J2_TEMPLATE_PATH).to_json(),
-            expected_json
+            expected_json,
+            blueprint.to_json()
         )
 
 

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -32,10 +32,13 @@ def mock_context(namespace="default", extra_config_args=None, **kwargs):
     if extra_config_args:
         config_args.update(extra_config_args)
     config = Config(config_args)
-    environment = kwargs.get("environment", {})
+    if kwargs.get("environment"):
+        return Context(
+            config=config,
+            **kwargs)
     return Context(
         config=config,
-        environment=environment,
+        environment={},
         **kwargs)
 
 

--- a/stacker/tests/fixtures/cfn_template.json.j2
+++ b/stacker/tests/fixtures/cfn_template.json.j2
@@ -1,0 +1,23 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "TestTemplate",
+    "Parameters": {
+        "Param1": {
+            "Type": "String"
+        },
+        "Param2": {
+            "Default": "default",
+            "Type": "CommaDelimitedList"
+        }
+    },
+    "Resources": {
+      "Dummy": {
+        "Type": "AWS::CloudFormation::WaitConditionHandle"
+      }
+    },
+    "Outputs": {
+      "DummyId": {
+        "Value": "dummy-{{ context.environment.foo }}-{{ variables.bar }}-1234"
+      }
+    }
+}

--- a/stacker/tests/fixtures/cfn_template.json.j2
+++ b/stacker/tests/fixtures/cfn_template.json.j2
@@ -17,7 +17,7 @@
     },
     "Outputs": {
       "DummyId": {
-        "Value": "dummy-{{ context.environment.foo }}-{{ variables.bar }}-1234"
+        "Value": "dummy-{{ context.environment.foo }}-{{ variables.Param1 }}-{{ variables.bar }}-1234"
       }
     }
 }


### PR DESCRIPTION
Decided to make it completely opt-in by requiring templates to be explicitly named `*.j2`, so this won't affect anyone that doesn't explicitly chose to use it.