### PR TITLE
Added Unit Test for hooks iam

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run: sudo pip install flake8 codecov pep8-naming flake8-future-import
       - run: sudo python setup.py install
       - run: flake8 --version
-      - run: sudo make lint
+      # - run: sudo make lint
 
   unit-test-27:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run: sudo pip install flake8 codecov pep8-naming flake8-future-import
       - run: sudo python setup.py install
       - run: flake8 --version
-      # - run: sudo make lint
+      - run: sudo make lint
 
   unit-test-27:
     docker:

--- a/stacker/tests/hooks/test_iam.py
+++ b/stacker/tests/hooks/test_iam.py
@@ -13,6 +13,8 @@ from stacker.hooks.iam import (
     _get_cert_arn_from_response,
 )
 
+from awacs.helpers.trust import get_ecs_assumerole_policy
+
 from ..factories import (
     mock_context,
     mock_provider,
@@ -23,6 +25,7 @@ REGION = "us-east-1"
 
 # No test for stacker.hooks.iam.ensure_server_cert_exists until
 # updated version of moto is imported
+# (https://github.com/spulec/moto/pull/679) merged
 
 
 class TestIAMHooks(unittest.TestCase):


### PR DESCRIPTION
Tests whether an ecs service role already exists. Potential for more unit testing with moto now that https://github.com/spulec/moto/pull/679 is merged