### PR TITLE
Added unit test for service role that exists

### DIFF
--- a/stacker/tests/hooks/test_iam.py
+++ b/stacker/tests/hooks/test_iam.py
@@ -13,6 +13,8 @@ from stacker.hooks.iam import (
     _get_cert_arn_from_response,
 )
 
+from awacs.helpers.trust import get_ecs_assumerole_policy
+
 from ..factories import (
     mock_context,
     mock_provider,
@@ -22,8 +24,8 @@ from ..factories import (
 REGION = "us-east-1"
 
 # No test for stacker.hooks.iam.ensure_server_cert_exists until
-# this PR is accepted in moto:
-# https://github.com/spulec/moto/pull/679
+# updated version of moto is imported
+# (https://github.com/spulec/moto/pull/679) merged
 
 
 class TestIAMHooks(unittest.TestCase):
@@ -55,6 +57,32 @@ class TestIAMHooks(unittest.TestCase):
 
             with self.assertRaises(ClientError):
                 client.get_role(RoleName=role_name)
+
+            self.assertTrue(
+                create_ecs_service_role(
+                    context=self.context,
+                    provider=self.provider,
+                )
+            )
+
+            role = client.get_role(RoleName=role_name)
+
+            self.assertIn("Role", role)
+            self.assertEqual(role_name, role["Role"]["RoleName"])
+            client.get_role_policy(
+                RoleName=role_name,
+                PolicyName=policy_name
+            )
+
+    def test_create_service_role_already_exists(self):
+        role_name = "ecsServiceRole"
+        policy_name = "AmazonEC2ContainerServiceRolePolicy"
+        with mock_iam():
+            client = boto3.client("iam", region_name=REGION)
+            client.create_role(
+                RoleName=role_name,
+                AssumeRolePolicyDocument=get_ecs_assumerole_policy().to_json()
+            )
 
             self.assertTrue(
                 create_ecs_service_role(


### PR DESCRIPTION
Tests whether an ecs service role already exists. Potential for more unit testing with an updated version of moto now that [spulec/moto#679](https://github.com/spulec/moto/pull/679) is merged