### PR TITLE
docs clarifications re blueprints and file lookups

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -2,8 +2,11 @@
 Blueprints
 ==========
 
-Blueprints are python classes that build CloudFormation templates.
-Traditionally these are built using troposphere_, but that is not absolutely
+Blueprints are python classes that dynamically build CloudFormation templates. Where
+you would specify a raw Cloudformation template in a stack using the ``template_path`` key,
+you instead specify a blueprint python file using the ``class_path`` key.
+
+Traditionally blueprints are built using troposphere_, but that is not absolutely
 necessary. You are encouraged to check out the library of publicly shared
 Blueprints in the stacker_blueprints_ package.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -226,7 +226,7 @@ The keyword is a list of dictionaries with the following keys:
   the python import path to the hook
 **data_key:**
   If set, and the hook returns data (a dictionary), the results will be stored
-  in the context.hook_data with the data_key as it's key.
+  in the context.hook_data with the data_key as its key.
 **required:**
   whether to stop execution if the hook fails
 **enabled:**

--- a/docs/lookups.rst
+++ b/docs/lookups.rst
@@ -250,7 +250,8 @@ Basic examples::
   conf_key: aGVsbG8gdGhlcmUK
 
 Supported codecs:
- - plain
+ - plain - load the contents of the file untouched. This is the only codec that should be used
+   with raw Cloudformation templates (the other codecs are intended for blueprints).
  - base64 - encode the plain text file at the given path with base64 prior
    to returning it
  - parameterized - the same as plain, but additionally supports


### PR DESCRIPTION
I'd been struggling to get `parameterized` lookups working, until a co-worker pointed out that it's only meant for blueprints, not templates.  D'oh!

I think these changes to the docs would have saved me some confusion. 