### PR TITLE
Update config.rst to fix external URI syntax

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -479,17 +479,16 @@ By default, stacker uses the following `log_formats`::
     color: "[%(asctime)s] \033[%(color)sm%(message)s\033[39m"
     debug: "[%(asctime)s] %(levelname)s %(threadName)s %(name)s:%(lineno)d(%(funcName)s): %(message)s"
 
-You may optionally provide custom `log_formats`.
-
-You may use any of the standard Python
-`logging module format attributes <https://docs.python.org/2.7/library/logging.html#logrecord-attributes>`_
-when building your `log_formats`.
-
-In this example, we add the environment name to each log line::
+You may optionally provide custom `log_formats`. In this example, we add the environment name to each log line::
 
   log_formats:
     info: "[%(asctime)s] ${environment} %(message)s"
     color: "[%(asctime)s] ${environment} \033[%(color)sm%(message)s\033[39m"
+    
+You may use any of the standard Python
+`logging module format attributes <https://docs.python.org/2.7/library/logging.html#logrecord-attributes>`_
+when building your `log_formats`.
+
 
 Variables
 ==========

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -482,7 +482,7 @@ By default, stacker uses the following `log_formats`::
 You may optionally provide custom `log_formats`.
 
 You may use any of the standard Python
-[logging module format attributes](https://docs.python.org/2.7/library/logging.html#logrecord-attributes)
+`logging module format attributes <https://docs.python.org/2.7/library/logging.html#logrecord-attributes>`_
 when building your `log_formats`.
 
 In this example, we add the environment name to each log line::


### PR DESCRIPTION
Fixes the syntax to properly render an external URI in docs.