### PR TITLE
Resolve lookups in hook args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Upcoming release
 
+- add the ability to resolve native lookups in hook args
+
 ## 1.6.0 (2019-01-21)
 
 - New lookup format/syntax, making it more generic [GH-665]

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -7,7 +7,7 @@ from .base import BaseAction, plan, build_walker
 from .base import STACK_POLL_TIME
 
 from ..providers.base import Template
-from .. import util
+from ..hooks import utils
 from ..exceptions import (
     MissingParameterException,
     StackDidNotChange,
@@ -196,7 +196,7 @@ def handle_hooks(stage, hooks, provider, context, dump, outline):
 
     """
     if not outline and not dump and hooks:
-        util.handle_hooks(
+        utils.handle_hooks(
             stage=stage,
             hooks=hooks,
             provider=provider,

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -6,7 +6,7 @@ import logging
 from .base import BaseAction, plan, build_walker
 from .base import STACK_POLL_TIME
 from ..exceptions import StackDoesNotExist
-from .. import util
+from ..hooks import utils
 from ..status import (
     CompleteStatus,
     SubmittedStatus,
@@ -82,7 +82,7 @@ class Action(BaseAction):
         """Any steps that need to be taken prior to running the action."""
         pre_destroy = self.context.config.pre_destroy
         if not outline and pre_destroy:
-            util.handle_hooks(
+            utils.handle_hooks(
                 stage="pre_destroy",
                 hooks=pre_destroy,
                 provider=self.provider,
@@ -106,7 +106,7 @@ class Action(BaseAction):
         """Any steps that need to be taken after running the action."""
         post_destroy = self.context.config.post_destroy
         if not outline and post_destroy:
-            util.handle_hooks(
+            utils.handle_hooks(
                 stage="post_destroy",
                 hooks=post_destroy,
                 provider=self.provider,

--- a/stacker/hooks/utils.py
+++ b/stacker/hooks/utils.py
@@ -2,7 +2,90 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 import os
+import sys
+import collections
+import logging
+
+from ..variables import Variable, resolve_variables
+from ..util import load_object_from_string
+
+logger = logging.getLogger(__name__)
 
 
 def full_path(path):
     return os.path.abspath(os.path.expanduser(path))
+
+
+def handle_hooks(stage, hooks, provider, context):
+    """ Used to handle pre/post_build hooks.
+
+    These are pieces of code that we want to run before/after the builder
+    builds the stacks.
+
+    Args:
+        stage (string): The current stage (pre_run, post_run, etc).
+        hooks (list): A list of :class:`stacker.config.Hook` containing the
+            hooks to execute.
+        provider (:class:`stacker.provider.base.BaseProvider`): The provider
+            the current stack is using.
+        context (:class:`stacker.context.Context`): The current stacker
+            context.
+    """
+    if not hooks:
+        logger.debug("No %s hooks defined.", stage)
+        return
+
+    hook_paths = []
+    for i, h in enumerate(hooks):
+        try:
+            hook_paths.append(h.path)
+        except KeyError:
+            raise ValueError("%s hook #%d missing path." % (stage, i))
+
+    logger.info("Executing %s hooks: %s", stage, ", ".join(hook_paths))
+    for hook in hooks:
+        data_key = hook.data_key
+        required = hook.required
+        enabled = hook.enabled
+
+        if isinstance(hook.args, dict):
+            args = [Variable(k, v) for k, v in hook.args.items()]
+            resolve_variables(args, context, provider)
+            kwargs = {v.name: v.value for v in args}
+        else:
+            kwargs = hook.args or {}
+
+        if not enabled:
+            logger.debug("hook with method %s is disabled, skipping",
+                         hook.path)
+            continue
+        try:
+            method = load_object_from_string(hook.path)
+        except (AttributeError, ImportError):
+            logger.exception("Unable to load method at %s:", hook.path)
+            if required:
+                raise
+            continue
+        try:
+            result = method(context=context, provider=provider, **kwargs)
+        except Exception:
+            logger.exception("Method %s threw an exception:", hook.path)
+            if required:
+                raise
+            continue
+        if not result:
+            if required:
+                logger.error("Required hook %s failed. Return value: %s",
+                             hook.path, result)
+                sys.exit(1)
+            logger.warning("Non-required hook %s failed. Return value: %s",
+                           hook.path, result)
+        else:
+            if isinstance(result, collections.Mapping):
+                if data_key:
+                    logger.debug("Adding result for hook %s to context in "
+                                 "data_key %s.", hook.path, data_key)
+                    context.set_hook_data(data_key, result)
+                else:
+                    logger.debug("Hook %s returned result data, but no data "
+                                 "key set, so ignoring.", hook.path)

--- a/stacker/tests/hooks/test_utils.py
+++ b/stacker/tests/hooks/test_utils.py
@@ -1,0 +1,158 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import unittest
+
+import queue
+
+from stacker.config import Hook
+from stacker.hooks.utils import handle_hooks
+
+from ..factories import (
+    mock_context,
+    mock_provider,
+)
+
+hook_queue = queue.Queue()
+
+
+def mock_hook(*args, **kwargs):
+    hook_queue.put(kwargs)
+    return True
+
+
+def fail_hook(*args, **kwargs):
+    return None
+
+
+def exception_hook(*args, **kwargs):
+    raise Exception
+
+
+def context_hook(*args, **kwargs):
+    return "context" in kwargs
+
+
+def result_hook(*args, **kwargs):
+    return {"foo": "bar"}
+
+
+class TestHooks(unittest.TestCase):
+
+    def setUp(self):
+        self.context = mock_context(namespace="namespace")
+        self.provider = mock_provider(region="us-east-1")
+
+    def test_empty_hook_stage(self):
+        hooks = []
+        handle_hooks("fake", hooks, self.provider, self.context)
+        self.assertTrue(hook_queue.empty())
+
+    def test_missing_required_hook(self):
+        hooks = [Hook({"path": "not.a.real.path", "required": True})]
+        with self.assertRaises(ImportError):
+            handle_hooks("missing", hooks, self.provider, self.context)
+
+    def test_missing_required_hook_method(self):
+        hooks = [{"path": "stacker.hooks.blah", "required": True}]
+        with self.assertRaises(AttributeError):
+            handle_hooks("missing", hooks, self.provider, self.context)
+
+    def test_missing_non_required_hook_method(self):
+        hooks = [Hook({"path": "stacker.hooks.blah", "required": False})]
+        handle_hooks("missing", hooks, self.provider, self.context)
+        self.assertTrue(hook_queue.empty())
+
+    def test_default_required_hook(self):
+        hooks = [Hook({"path": "stacker.hooks.blah"})]
+        with self.assertRaises(AttributeError):
+            handle_hooks("missing", hooks, self.provider, self.context)
+
+    def test_valid_hook(self):
+        hooks = [
+            Hook({"path": "stacker.tests.hooks.test_utils.mock_hook",
+                  "required": True})]
+        handle_hooks("missing", hooks, self.provider, self.context)
+        good = hook_queue.get_nowait()
+        self.assertEqual(good["provider"].region, "us-east-1")
+        with self.assertRaises(queue.Empty):
+            hook_queue.get_nowait()
+
+    def test_valid_enabled_hook(self):
+        hooks = [
+            Hook({"path": "stacker.tests.hooks.test_utils.mock_hook",
+                  "required": True, "enabled": True})]
+        handle_hooks("missing", hooks, self.provider, self.context)
+        good = hook_queue.get_nowait()
+        self.assertEqual(good["provider"].region, "us-east-1")
+        with self.assertRaises(queue.Empty):
+            hook_queue.get_nowait()
+
+    def test_valid_enabled_false_hook(self):
+        hooks = [
+            Hook({"path": "stacker.tests.hooks.test_utils.mock_hook",
+                  "required": True, "enabled": False})]
+        handle_hooks("missing", hooks, self.provider, self.context)
+        self.assertTrue(hook_queue.empty())
+
+    def test_context_provided_to_hook(self):
+        hooks = [
+            Hook({"path": "stacker.tests.hooks.test_utils.context_hook",
+                  "required": True})]
+        handle_hooks("missing", hooks, "us-east-1", self.context)
+
+    def test_hook_failure(self):
+        hooks = [
+            Hook({"path": "stacker.tests.hooks.test_utils.fail_hook",
+                  "required": True})]
+        with self.assertRaises(SystemExit):
+            handle_hooks("fail", hooks, self.provider, self.context)
+        hooks = [{"path": "stacker.tests.hooks.test_utils.exception_hook",
+                  "required": True}]
+        with self.assertRaises(Exception):
+            handle_hooks("fail", hooks, self.provider, self.context)
+        hooks = [
+            Hook({"path": "stacker.tests.hooks.test_utils.exception_hook",
+                  "required": False})]
+        # Should pass
+        handle_hooks("ignore_exception", hooks, self.provider, self.context)
+
+    def test_return_data_hook(self):
+        hooks = [
+            Hook({
+                "path": "stacker.tests.hooks.test_utils.result_hook",
+                "data_key": "my_hook_results"
+            }),
+            # Shouldn't return data
+            Hook({
+                "path": "stacker.tests.hooks.test_utils.context_hook"
+            })
+        ]
+        handle_hooks("result", hooks, "us-east-1", self.context)
+
+        self.assertEqual(
+            self.context.hook_data["my_hook_results"]["foo"],
+            "bar"
+        )
+        # Verify only the first hook resulted in stored data
+        self.assertEqual(
+            list(self.context.hook_data.keys()), ["my_hook_results"]
+        )
+
+    def test_return_data_hook_duplicate_key(self):
+        hooks = [
+            Hook({
+                "path": "stacker.tests.hooks.test_utils.result_hook",
+                "data_key": "my_hook_results"
+            }),
+            Hook({
+                "path": "stacker.tests.hooks.test_utils.result_hook",
+                "data_key": "my_hook_results"
+            })
+        ]
+
+        with self.assertRaises(KeyError):
+            handle_hooks("result", hooks, "us-east-1", self.context)

--- a/stacker/tests/hooks/test_utils.py
+++ b/stacker/tests/hooks/test_utils.py
@@ -40,6 +40,10 @@ def result_hook(*args, **kwargs):
     return {"foo": "bar"}
 
 
+def kwargs_hook(*args, **kwargs):
+    return kwargs
+
+
 class TestHooks(unittest.TestCase):
 
     def setUp(self):
@@ -156,3 +160,20 @@ class TestHooks(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             handle_hooks("result", hooks, "us-east-1", self.context)
+
+    def test_resolve_lookups_in_args(self):
+        hooks = [
+            Hook({
+                "path": "stacker.tests.hooks.test_utils.kwargs_hook",
+                "data_key": "my_hook_results",
+                "args": {
+                    "default_lookup": "${default env_var::default_value}"
+                }
+            })
+        ]
+        handle_hooks("lookups", hooks, "us-east-1", self.context)
+
+        self.assertEqual(
+            self.context.hook_data["my_hook_results"]["default_lookup"],
+            "default_value"
+        )

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -5,7 +5,7 @@ import unittest
 
 from stacker.context import Context, get_fqn
 from stacker.config import load, Config
-from stacker.util import handle_hooks
+from stacker.hooks.utils import handle_hooks
 
 
 class TestContext(unittest.TestCase):

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -8,18 +8,16 @@ import unittest
 
 import string
 import os
-import queue
 
 import mock
 
 import boto3
 
-from stacker.config import Hook, GitPackageSource
+from stacker.config import GitPackageSource
 from stacker.util import (
     cf_safe_name,
     load_object_from_string,
     camel_to_snake,
-    handle_hooks,
     merge_map,
     yaml_to_ordered_dict,
     get_client_region,
@@ -33,10 +31,6 @@ from stacker.util import (
     SourceProcessor
 )
 
-from .factories import (
-    mock_context,
-    mock_provider,
-)
 
 regions = ["us-east-1", "cn-north-1", "ap-northeast-1", "eu-west-1",
            "ap-southeast-1", "ap-southeast-2", "us-west-2", "us-gov-west-1",
@@ -272,148 +266,6 @@ Outputs:
                 sp.determine_git_ref({'uri': 'git@foo', 'tag': 'v1.0.0'}),
                 'v1.0.0'
             )
-
-
-hook_queue = queue.Queue()
-
-
-def mock_hook(*args, **kwargs):
-    hook_queue.put(kwargs)
-    return True
-
-
-def fail_hook(*args, **kwargs):
-    return None
-
-
-def exception_hook(*args, **kwargs):
-    raise Exception
-
-
-def context_hook(*args, **kwargs):
-    return "context" in kwargs
-
-
-def result_hook(*args, **kwargs):
-    return {"foo": "bar"}
-
-
-class TestHooks(unittest.TestCase):
-
-    def setUp(self):
-        self.context = mock_context(namespace="namespace")
-        self.provider = mock_provider(region="us-east-1")
-
-    def test_empty_hook_stage(self):
-        hooks = []
-        handle_hooks("fake", hooks, self.provider, self.context)
-        self.assertTrue(hook_queue.empty())
-
-    def test_missing_required_hook(self):
-        hooks = [Hook({"path": "not.a.real.path", "required": True})]
-        with self.assertRaises(ImportError):
-            handle_hooks("missing", hooks, self.provider, self.context)
-
-    def test_missing_required_hook_method(self):
-        hooks = [{"path": "stacker.hooks.blah", "required": True}]
-        with self.assertRaises(AttributeError):
-            handle_hooks("missing", hooks, self.provider, self.context)
-
-    def test_missing_non_required_hook_method(self):
-        hooks = [Hook({"path": "stacker.hooks.blah", "required": False})]
-        handle_hooks("missing", hooks, self.provider, self.context)
-        self.assertTrue(hook_queue.empty())
-
-    def test_default_required_hook(self):
-        hooks = [Hook({"path": "stacker.hooks.blah"})]
-        with self.assertRaises(AttributeError):
-            handle_hooks("missing", hooks, self.provider, self.context)
-
-    def test_valid_hook(self):
-        hooks = [
-            Hook({"path": "stacker.tests.test_util.mock_hook",
-                  "required": True})]
-        handle_hooks("missing", hooks, self.provider, self.context)
-        good = hook_queue.get_nowait()
-        self.assertEqual(good["provider"].region, "us-east-1")
-        with self.assertRaises(queue.Empty):
-            hook_queue.get_nowait()
-
-    def test_valid_enabled_hook(self):
-        hooks = [
-            Hook({"path": "stacker.tests.test_util.mock_hook",
-                  "required": True, "enabled": True})]
-        handle_hooks("missing", hooks, self.provider, self.context)
-        good = hook_queue.get_nowait()
-        self.assertEqual(good["provider"].region, "us-east-1")
-        with self.assertRaises(queue.Empty):
-            hook_queue.get_nowait()
-
-    def test_valid_enabled_false_hook(self):
-        hooks = [
-            Hook({"path": "stacker.tests.test_util.mock_hook",
-                  "required": True, "enabled": False})]
-        handle_hooks("missing", hooks, self.provider, self.context)
-        self.assertTrue(hook_queue.empty())
-
-    def test_context_provided_to_hook(self):
-        hooks = [
-            Hook({"path": "stacker.tests.test_util.context_hook",
-                  "required": True})]
-        handle_hooks("missing", hooks, "us-east-1", self.context)
-
-    def test_hook_failure(self):
-        hooks = [
-            Hook({"path": "stacker.tests.test_util.fail_hook",
-                  "required": True})]
-        with self.assertRaises(SystemExit):
-            handle_hooks("fail", hooks, self.provider, self.context)
-        hooks = [{"path": "stacker.tests.test_util.exception_hook",
-                  "required": True}]
-        with self.assertRaises(Exception):
-            handle_hooks("fail", hooks, self.provider, self.context)
-        hooks = [
-            Hook({"path": "stacker.tests.test_util.exception_hook",
-                  "required": False})]
-        # Should pass
-        handle_hooks("ignore_exception", hooks, self.provider, self.context)
-
-    def test_return_data_hook(self):
-        hooks = [
-            Hook({
-                "path": "stacker.tests.test_util.result_hook",
-                "data_key": "my_hook_results"
-            }),
-            # Shouldn't return data
-            Hook({
-                "path": "stacker.tests.test_util.context_hook"
-            })
-        ]
-        handle_hooks("result", hooks, "us-east-1", self.context)
-
-        self.assertEqual(
-            self.context.hook_data["my_hook_results"]["foo"],
-            "bar"
-        )
-        # Verify only the first hook resulted in stored data
-        self.assertEqual(
-            list(self.context.hook_data.keys()), ["my_hook_results"]
-        )
-
-    def test_return_data_hook_duplicate_key(self):
-        hooks = [
-            Hook({
-                "path": "stacker.tests.test_util.result_hook",
-                "data_key": "my_hook_results"
-            }),
-            Hook({
-                "path": "stacker.tests.test_util.result_hook",
-                "data_key": "my_hook_results"
-            })
-        ]
-
-        with self.assertRaises(KeyError):
-            handle_hooks("result", hooks, "us-east-1", self.context)
 
 
 class TestException1(Exception):

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -16,7 +16,6 @@ import tarfile
 import tempfile
 import zipfile
 
-import collections
 from collections import OrderedDict
 
 import botocore.client
@@ -335,74 +334,6 @@ def cf_safe_name(name):
     alphanumeric = r"[a-zA-Z0-9]+"
     parts = re.findall(alphanumeric, name)
     return "".join([uppercase_first_letter(part) for part in parts])
-
-
-def handle_hooks(stage, hooks, provider, context):
-    """ Used to handle pre/post_build hooks.
-
-    These are pieces of code that we want to run before/after the builder
-    builds the stacks.
-
-    Args:
-        stage (string): The current stage (pre_run, post_run, etc).
-        hooks (list): A list of :class:`stacker.config.Hook` containing the
-            hooks to execute.
-        provider (:class:`stacker.provider.base.BaseProvider`): The provider
-            the current stack is using.
-        context (:class:`stacker.context.Context`): The current stacker
-            context.
-    """
-    if not hooks:
-        logger.debug("No %s hooks defined.", stage)
-        return
-
-    hook_paths = []
-    for i, h in enumerate(hooks):
-        try:
-            hook_paths.append(h.path)
-        except KeyError:
-            raise ValueError("%s hook #%d missing path." % (stage, i))
-
-    logger.info("Executing %s hooks: %s", stage, ", ".join(hook_paths))
-    for hook in hooks:
-        data_key = hook.data_key
-        required = hook.required
-        kwargs = hook.args or {}
-        enabled = hook.enabled
-        if not enabled:
-            logger.debug("hook with method %s is disabled, skipping",
-                         hook.path)
-            continue
-        try:
-            method = load_object_from_string(hook.path)
-        except (AttributeError, ImportError):
-            logger.exception("Unable to load method at %s:", hook.path)
-            if required:
-                raise
-            continue
-        try:
-            result = method(context=context, provider=provider, **kwargs)
-        except Exception:
-            logger.exception("Method %s threw an exception:", hook.path)
-            if required:
-                raise
-            continue
-        if not result:
-            if required:
-                logger.error("Required hook %s failed. Return value: %s",
-                             hook.path, result)
-                sys.exit(1)
-            logger.warning("Non-required hook %s failed. Return value: %s",
-                           hook.path, result)
-        else:
-            if isinstance(result, collections.Mapping):
-                if data_key:
-                    logger.debug("Adding result for hook %s to context in "
-                                 "data_key %s.", hook.path, data_key)
-                    context.set_hook_data(data_key, result)
-                else:
-                    logger.debug("Hook %s returned result data, but no data "
-                                 "key set, so ignoring.", hook.path)
 
 
 def get_config_directory():


### PR DESCRIPTION
This change allows for the resolution of all `stacker.lookups` passed into a hook's args without needing to add a handler to each hook.

Previously, only lookups to the provided `.env` were resolvable or logic had to be added to hooks individually to handle lookups.

# Example Usage
```yaml
pre_build:
  testing-hook-lookup-resolve:
    path: hooks.test_hook.test
    args:
      rxref_lookup: ${rxref common-vpc::VpcId}
      nested_dict:
        xref_lookup: ${xref finley-lab-common-vpc::VpcCidrBlock}
      list_lookups:
        - ${default env_var::default_value}
```

# Output
```
[2019-03-09T19:11:54] Using default AWS provider mode
[2019-03-09T19:11:54] Executing pre_build hooks: hooks.test_hook.test
[2019-03-09T19:11:54] rxref_lookup: vpc-xxxxxx
[2019-03-09T19:11:54] list_lookups: ['default_value']
[2019-03-09T19:11:54] nested_dict: {'xref_lookup': '10.0.0.0/16'}
[2019-03-09T19:11:54] ignore-this-stack: skipped (disabled)
```