### PR TITLE
add botocore minimum version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ src_dir = os.path.dirname(__file__)
 install_requires = [
     "future",
     "troposphere>=1.9.0",
-    "botocore",
+    'botocore>=1.12.111',  # matching boto3 requirement
     "boto3>=1.9.111<2.0",
     "PyYAML>=3.13b1",
     "awacs>=0.6.0",


### PR DESCRIPTION
Fixes #726

The problem now is pip isn't picking up on the transitive dependency on a newer botocore in our specified version of boto3.