### PR TITLE
test diff before the stack exists

### DIFF
--- a/tests/test_suite/27_stacker_diff-raw_template.bats
+++ b/tests/test_suite/27_stacker_diff-raw_template.bats
@@ -31,6 +31,10 @@ EOF
     stacker destroy --force <(config1)
   }
 
+  # Test the diff with a stack that doesn't exist
+  stacker diff <(config2)
+  assert "$status" -eq 0
+
   # Create the new stacks.
   stacker build <(config1)
   assert "$status" -eq 0


### PR DESCRIPTION
Currently a diff will fail if the stack doesn't exist.  Most of the logic is there but it doesn't fully cover it. 

I'm still not sure how the outputs should be fully handled so not changing it much but only appending it if the stack currently exists.