### PR TITLE
Fix ami lookup 'Name' key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Upcoming release
+- Fixing AMI lookup Key error on 'Name'
 
 ## 1.7.0 (2019-04-07)
 

--- a/stacker/lookups/handlers/ami.py
+++ b/stacker/lookups/handlers/ami.py
@@ -93,7 +93,7 @@ class AmiLookup(LookupHandler):
                         key=operator.itemgetter('CreationDate'),
                         reverse=True)
         for image in images:
-            if re.match("^%s$" % name_regex, image['Name']):
+            if re.match("^%s$" % name_regex, image.get('Name', '')):
                 return image['ImageId']
 
         raise ImageNotFound(value)


### PR DESCRIPTION
When looking for an AMI that does not exist on us-east-1 and us-west-1 (have not tested the regions) that belong to amazon the ami lookup function finds some old ARIs or AKIs. See the example below

`{'Architecture': 'x86_64', 'CreationDate': '2011-06-24T20:34:25.000Z', 'ImageId': 'ari-e6bc478f', 'ImageLocation': 'ec2-paid-ibm-was-us-east-1/initrd-2.6.16.60-0.30-xen.x86_64.manifest.xml', 'ImageType': 'ramdisk', 'Public': True, 'OwnerId': '470254534024', 'State': 'available', 'BlockDeviceMappings': [], 'Hypervisor': 'xen', 'ImageOwnerAlias': 'amazon', 'RootDeviceType': 'instance-store', 'VirtualizationType': 'paravirtual'}`

As you can see the above dict does not have the 'Name' key. This causes line 96 to fail with a Key error  such as the below

`(Couldn't resolve lookup in variable `AppAMI`, lookup: ${Lookup<Literal<'ami'> Literal<'owners:amazon name_regex:ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-[.0-9]+'>>}: (<class 'KeyError'>) 'Name')`

This is not the expected error message which should be 
`failed (Couldn't resolve lookup in variable `AppAMI`, lookup: ${Lookup<Literal<'ami'> Literal<'owners:amazon name_regex:ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-[.0-9]+'>>}: (<class 'stacker.lookups.handlers.ami.ImageNotFound'>) Unable to find ec2 image with search string: owners:amazon name_regex:ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-[.0-9]+)`

This changes the key access to a .get() with a default return of empty string in order to satisfy the string requirement of re.match().