### PR TITLE
Add YAML environment file support

### DIFF
--- a/docs/environments.rst
+++ b/docs/environments.rst
@@ -3,7 +3,15 @@ Environments
 ============
 
 When running stacker, you can optionally provide an "environment" file. The
-stacker config file will be interpolated as a `string.Template
+environment file defines values, which can then be referred to by name from
+your stack config file. The environment file is interpreted as YAML if it
+ends in `.yaml` or `.yml`, otherwise it's interpreted as simple key/value
+pairs.
+
+Key/Value environments
+----------------------
+
+The stacker config file will be interpolated as a `string.Template
 <https://docs.python.org/2/library/string.html#template-strings>`_ using the
 key/value pairs from the environment file. The format of the file is a single
 key/value per line, separated by a colon (**:**), like this::
@@ -42,6 +50,58 @@ files in your config. For example::
       class_path: stacker_blueprints.asg.AutoscalingGroup
       variables:
         InstanceType: ${web_instance_type}
+
+YAML environments
+-----------------
+
+YAML environments allow for more complex environment configuration rather
+than simple text substitution, and support YAML features like anchors and
+references. To build on the example above, let's define a stack that's
+a little more complex::
+
+  stacks:
+    - name: webservers
+      class_path: stacker_blueprints.asg.AutoscalingGroup
+      variables:
+        InstanceType: ${web_instance_type}
+        IngressCIDRsByPort: ${ingress_cidrs_by_port}
+
+We've defined a stack which expects a list of ingress CIDR's allowed access to
+each port. Our environment files would look like this::
+
+  # in the file: stage.env
+  web_instance_type: m3.medium
+  ingress_cidrs_by_port:
+    80:
+      - 192.168.1.0/8
+    8080:
+      - 0.0.0.0/0
+
+  # in the file: prod.env
+  web_instance_type: c4.xlarge
+  ingress_cidrs_by_port:
+    80:
+      - 192.168.1.0/8
+    443:
+      - 10.0.0.0/16
+      - 10.1.0.0/16
+
+The YAML format allows for specifying lists, maps, and supports all `pyyaml`
+functionality allowed in `safe_load()` function.
+
+Variable substitution in the YAML case is a bit more complex than in the
+`string.Template` case. Objects can only be substituted for variables in the
+case where we perform a full substitution, such as this::
+
+  vpcID: ${vpc_variable}
+
+We can not substitute an object in a sub-string, such as this::
+
+  vpcID: prefix-${vpc_variable}
+
+It makes no sense to substitute a complex object in this case, and we will raise
+an error if that happens. You can still perform this substitution with
+primitives; numbers, strings, but not dicts or lists.
 
 .. note::
   Namespace defined in the environment file has been deprecated in favor of

--- a/docs/environments.rst
+++ b/docs/environments.rst
@@ -69,7 +69,7 @@ a little more complex::
 We've defined a stack which expects a list of ingress CIDR's allowed access to
 each port. Our environment files would look like this::
 
-  # in the file: stage.env
+  # in the file: stage.yml
   web_instance_type: m3.medium
   ingress_cidrs_by_port:
     80:

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -69,7 +69,7 @@ def key_value_arg(string):
 def environment_file(input_file):
     """Reads a stacker environment file and returns the resulting data."""
 
-    is_yaml = os.path.splitext(input_file)[1] in ['.yaml', '.yml']
+    is_yaml = os.path.splitext(input_file)[1].lower() in ['.yaml', '.yml']
 
     with open(input_file) as fd:
         if is_yaml:

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -7,8 +7,13 @@ import threading
 import signal
 from collections import Mapping
 import logging
+import os.path
 
-from ...environment import parse_environment
+from ...environment import (
+    DictWithSourceType,
+    parse_environment,
+    parse_yaml_environment
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +68,14 @@ def key_value_arg(string):
 
 def environment_file(input_file):
     """Reads a stacker environment file and returns the resulting data."""
+
+    is_yaml = os.path.splitext(input_file)[1] in ['.yaml', '.yml']
+
     with open(input_file) as fd:
-        return parse_environment(fd.read())
+        if is_yaml:
+            return parse_yaml_environment(fd.read())
+        else:
+            return parse_environment(fd.read())
 
 
 class BaseCommand(object):
@@ -158,12 +169,17 @@ class BaseCommand(object):
             "-v", "--verbose", action="count", default=0,
             help="Increase output verbosity. May be specified up to twice.")
         parser.add_argument(
-            "environment", type=environment_file, nargs='?', default={},
-            help="Path to a simple `key: value` pair environment file. The "
-                 "values in the environment file can be used in the stack "
-                 "config as if it were a string.Template type: "
+            "environment", type=environment_file, nargs='?',
+            default=DictWithSourceType('simple'),
+            help="Path to an environment file. The file can be a simple "
+                 "`key: value` pair environment file, or a YAML file ending in"
+                 ".yaml or .yml. In the simple key:value case, values in the "
+                 "environment file can be used in the stack config as if it "
+                 "were a string.Template type: "
                  "https://docs.python.org/2/library/"
-                 "string.html#template-strings.")
+                 "string.html#template-strings. In the YAML case, variable"
+                 "references in the stack config are replaced with the objects"
+                 "in the environment after parsing")
         parser.add_argument(
             "config", type=argparse.FileType(),
             help="The config file where stack configuration is located. Must "

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -206,7 +206,6 @@ def substitute_references(root, environment, exp, full_exp):
         # partial substitutions within a string.
         def replace(mo):
             name = mo.groupdict()['braced'] or mo.groupdict()['named']
-            print('yyy', mo.groupdict(), root, name)
             if not name:
                 return root[mo.start():mo.end()]
             val = environment.get(name)

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -116,11 +116,10 @@ def render(raw_config, environment=None):
               (?P<named>%(id)s)      |   # delimiter and a Python identifier
               {(?P<braced>%(bid)s)}  |   # delimiter and a braced identifier
             )
-            """ % {
-                'delim': re.escape('$'),
-                'id': idpattern,
-                'bid': idpattern,
-            }
+            """ % {'delim': re.escape('$'),
+                   'id': idpattern,
+                   'bid': idpattern,
+                   }
         exp = re.compile(pattern, re.IGNORECASE | re.VERBOSE)
         new_config = substitute_references(config, environment, exp)
         # Now, re-encode the whole thing as YAML and return that.

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -158,6 +158,14 @@ class MissingEnvironment(Exception):
         super(MissingEnvironment, self).__init__(message, *args, **kwargs)
 
 
+class WrongEnvironmentType(Exception):
+
+    def __init__(self, key, *args, **kwargs):
+        self.key = key
+        message = "Environment key %s can't be merged into a string" % (key,)
+        super(WrongEnvironmentType, self).__init__(message, *args, **kwargs)
+
+
 class ImproperlyConfigured(Exception):
 
     def __init__(self, cls, error, *args, **kwargs):

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -46,6 +46,7 @@ def create_ecs_service_role(provider, context, **kwargs):
             raise
 
     policy = Policy(
+        Version='2012-10-17',
         Statement=[
             Statement(
                 Effect=Allow,

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -88,7 +88,6 @@ class TestConfig(unittest.TestCase):
             str_1: another str
             str_2: hello
             empty_string: ""
-            
         """
         e = parse_yaml_environment(env)
         c = render(conf, e)

--- a/stacker/tests/test_environment.py
+++ b/stacker/tests/test_environment.py
@@ -3,7 +3,10 @@ from __future__ import division
 from __future__ import absolute_import
 import unittest
 
-from stacker.environment import parse_environment
+from stacker.environment import (
+    DictWithSourceType,
+    parse_environment
+)
 
 test_env = """key1: value1
 # some: comment
@@ -31,7 +34,7 @@ class TestEnvironment(unittest.TestCase):
 
     def test_simple_key_value_parsing(self):
         parsed_env = parse_environment(test_env)
-        self.assertTrue(isinstance(parsed_env, dict))
+        self.assertTrue(isinstance(parsed_env, DictWithSourceType))
         self.assertEqual(parsed_env["key1"], "value1")
         self.assertEqual(parsed_env["key2"], "value2")
         self.assertEqual(parsed_env["key3"], "some:complex::value")


### PR DESCRIPTION
Environment files ending in .yaml or .yml will be rendered using
a different strategy. The env file is treated as a dict, with
the value for each key being a parsed YAML object. After parsing
the config, we look for things that look like variable references,
and replace the references with objects.