### PR TITLE
Fix IAM test errors due to missing version

### DIFF
--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -46,6 +46,7 @@ def create_ecs_service_role(provider, context, **kwargs):
             raise
 
     policy = Policy(
+        Version='2012-10-17',
         Statement=[
             Statement(
                 Effect=Allow,


### PR DESCRIPTION
Moto is requiring policy documents to be at least version
2012-10-17, so add that property.