### PR TITLE
Ensure that base64 lookup codec encodes the bytes object as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Upcoming release
 
+- Ensure that base64 lookup codec encodes the bytes object as a string [GH-742]
+
 ## 1.7.0 (2019-04-07)
 
 - Additional ECS unit tests [GH-696]

--- a/stacker/lookups/handlers/file.py
+++ b/stacker/lookups/handlers/file.py
@@ -218,7 +218,7 @@ def json_codec(raw, parameterized=False):
 
 CODECS = {
     "plain": lambda x: x,
-    "base64": lambda x: base64.b64encode(x.encode('utf8')),
+    "base64": lambda x: base64.b64encode(x.encode('utf8')).decode('utf-8'),
     "parameterized": lambda x: parameterized_codec(x, False),
     "parameterized-b64": lambda x: parameterized_codec(x, True),
     "yaml": lambda x: yaml_codec(x, parameterized=False),

--- a/stacker/tests/lookups/handlers/test_file.py
+++ b/stacker/tests/lookups/handlers/test_file.py
@@ -125,7 +125,7 @@ class TestFileTranslator(unittest.TestCase):
     @mock.patch('stacker.lookups.handlers.file.read_value_from_path')
     def test_handler_b64(self, content_mock):
         plain = u'Hello, world'
-        encoded = base64.b64encode(plain.encode('utf8'))
+        encoded = base64.b64encode(plain.encode('utf8')).decode('utf-8')
 
         content_mock.return_value = plain
         out = FileLookup.handle(u'base64:file://tmp/test')


### PR DESCRIPTION
We recently updated our python runtime for stacker from 2 to 3, and using the `file` lookup with the `base64` codec results in the output being a bytes object (`b'foo...'`), instead of a string that's usable as a CFN parameter or even a local stacker variable.

Fixes #693.