### PR TITLE
change diff to use CFN change sets instead of comparing template dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming release
 
 - Ensure that base64 lookup codec encodes the bytes object as a string [GH-742]
+- Use CloudFormation Change Sets for `stacker diff`
 
 ## 1.7.0 (2019-04-07)
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -103,7 +103,7 @@ already been destroyed).
     config                The config file where stack configuration is located.
                           Must be in yaml format. If `-` is provided, then the
                           config will be read from stdin.
-                          
+
   optional arguments:
     -h, --help            show this help message and exit
     -e ENV=VALUE, --env ENV=VALUE
@@ -182,10 +182,17 @@ config.
 Diff
 ----
 
-Diff attempts to show the differences between what stacker expects to push up
-into CloudFormation, and what already exists in CloudFormation.  This command
-is not perfect, as following things like *Ref* and *GetAtt* are not currently
-possible, but it should give a good idea if anything has changed.
+Diff creates a CloudFormation Change Set for each stack and displays the
+resulting changes. This works for stacks that already exist and new stacks.
+
+For stacks that are dependent on outputs from other stacks in the same file,
+stacker will infer that an update was made to the "parent" stack and invalidate
+outputs from resources that were changed and replace their value with
+``<inferred-change: stackName.outputName=unresolvedValue>``. This is done to
+illustrate the potential blast radius of a change and assist in tracking down
+why subsequent stacks could change. This inference is not perfect but takes a
+"best effort" approach to showing potential change between stacks that rely on
+each others outputs.
 
 ::
 

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -3,16 +3,12 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import str
 from builtins import object
-import difflib
-import json
 import logging
 from operator import attrgetter
 
 from .base import plan, build_walker
 from . import build
-from ..ui import ui
 from .. import exceptions
-from ..util import parse_cloudformation_template
 from ..status import (
     NotSubmittedStatus,
     NotUpdatedStatus,
@@ -148,49 +144,6 @@ def diff_parameters(old_params, new_params):
     return diff
 
 
-def normalize_json(template):
-    """Normalize our template for diffing.
-
-    Args:
-        template(str): string representing the template
-
-    Returns:
-        list: json representation of the parameters
-    """
-    obj = parse_cloudformation_template(template)
-    json_str = json.dumps(
-        obj, sort_keys=True, indent=4, default=str, separators=(',', ': '),
-    )
-    result = []
-    lines = json_str.split("\n")
-    for line in lines:
-        result.append(line + "\n")
-    return result
-
-
-def build_stack_changes(stack_name, new_stack, old_stack, new_params,
-                        old_params):
-    """Builds a list of strings to represent the the parameters (if changed)
-     and stack diff"""
-    from_file = "old_%s" % (stack_name,)
-    to_file = "new_%s" % (stack_name,)
-    lines = difflib.context_diff(
-        old_stack, new_stack,
-        fromfile=from_file, tofile=to_file,
-        n=7)  # ensure at least a few lines of context are displayed afterward
-
-    template_changes = list(lines)
-    log_lines = []
-    if not template_changes:
-        log_lines.append("*** No changes to template ***")
-    param_diffs = diff_parameters(old_params, new_params)
-    if param_diffs:
-        log_lines.append(format_params_diff(param_diffs))
-    if template_changes:
-        log_lines.append("".join(template_changes))
-    return log_lines
-
-
 class Action(build.Action):
     """ Responsible for diff'ing CF stacks in AWS and on disk
 
@@ -202,20 +155,6 @@ class Action(build.Action):
     AWS and compare it to the generated templated based on the current
     config.
     """
-
-    def _build_new_template(self, stack, parameters):
-        """Constructs the parameters & contents of a new stack and returns a
-        list(str) representation to be output to the user
-        """
-        log_lines = ["New template parameters:"]
-        for param in sorted(parameters,
-                            key=lambda param: param['ParameterKey']):
-            log_lines.append("%s = %s" % (param['ParameterKey'],
-                                          param['ParameterValue']))
-
-        log_lines.append("\nNew template contents:")
-        log_lines.append("".join(stack))
-        return log_lines
 
     def _diff_stack(self, stack, **kwargs):
         """Handles the diffing a stack in CloudFormation vs our config"""
@@ -230,15 +169,14 @@ class Action(build.Action):
 
         provider = self.build_provider(stack)
 
-        provider_stack = provider.get_stack(stack.fqn)
-
-        # get the current stack template & params from AWS
         try:
-            [old_template, old_params] = provider.get_stack_info(
-                provider_stack)
+            provider_stack = provider.get_stack(stack.fqn)
+            old_params = provider_stack.get('Parameters', [])
+            change_type = 'UPDATE'
         except exceptions.StackDoesNotExist:
-            old_template = None
+            provider_stack = None
             old_params = {}
+            change_type = 'CREATE'
 
         stack.resolve(self.context, provider)
         # generate our own template & params
@@ -246,34 +184,11 @@ class Action(build.Action):
         new_params = dict()
         for p in parameters:
             new_params[p['ParameterKey']] = p['ParameterValue']
-        new_template = stack.blueprint.rendered
-        new_stack = normalize_json(new_template)
 
-        output = ["============== Stack: %s ==============" % (stack.name,)]
-        # If this is a completely new template dump our params & stack
-        if not old_template:
-            output.extend(self._build_new_template(new_stack, parameters))
-        else:
-            # Diff our old & new stack/parameters
-            old_template = parse_cloudformation_template(old_template)
-            if isinstance(old_template, str):
-                # YAML templates returned from CFN need parsing again
-                # "AWSTemplateFormatVersion: \"2010-09-09\"\nParam..."
-                # ->
-                # AWSTemplateFormatVersion: "2010-09-09"
-                old_template = parse_cloudformation_template(old_template)
-            old_stack = normalize_json(
-                json.dumps(old_template,
-                           sort_keys=True,
-                           indent=4,
-                           default=str)
-            )
-            output.extend(build_stack_changes(stack.name, new_stack, old_stack,
-                                              new_params, old_params))
-        ui.info('\n' + '\n'.join(output))
-
-        stack.set_outputs(
-            provider.get_output_dict(provider_stack))
+        provider.get_stack_changes(
+            stack.fqn, self._template(stack.blueprint), old_params,
+            parameters, None, [], change_type
+        )
 
         return COMPLETE
 

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -151,9 +151,8 @@ class Action(build.Action):
     are determined automatically based on references to output values from
     other stacks).
 
-    The plan is then used to pull the current CloudFormation template from
-    AWS and compare it to the generated templated based on the current
-    config.
+    The plan is then used to create a changeset for a stack using a
+    generated template based on the current config.
     """
 
     def _diff_stack(self, stack, **kwargs):

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -5,6 +5,7 @@ from builtins import str
 from builtins import object
 import logging
 from operator import attrgetter
+import json  # TODO remove
 
 from .base import plan, build_walker
 from . import build
@@ -168,15 +169,22 @@ class Action(build.Action):
             return NotUpdatedStatus()
 
         provider = self.build_provider(stack)
+        tags = build.build_stack_tags(stack)
 
         try:
             provider_stack = provider.get_stack(stack.fqn)
+            # handling for orphaned changeset temp stacks
+            if provider.get_stack_status(
+                    provider_stack) == provider.REVIEW_STATUS:
+                raise exceptions.StackDoesNotExist(stack.fqn)
             old_params = provider_stack.get('Parameters', [])
             change_type = 'UPDATE'
+            stack_outputs = provider.get_outputs(stack.fqn)
         except exceptions.StackDoesNotExist:
             provider_stack = None
             old_params = {}
             change_type = 'CREATE'
+            stack_outputs = {}
 
         stack.resolve(self.context, provider)
         # generate our own template & params
@@ -185,10 +193,25 @@ class Action(build.Action):
         for p in parameters:
             new_params[p['ParameterKey']] = p['ParameterValue']
 
-        provider.get_stack_changes(
-            stack.fqn, self._template(stack.blueprint), old_params,
-            parameters, None, [], change_type
-        )
+        try:
+            provider.get_stack_changes(
+                stack.fqn, self._template(stack.blueprint), old_params,
+                parameters, None, tags, change_type,
+                outputs=stack.blueprint.get_output_definitions()
+            )
+            for output_name, output_params in \
+                    stack.blueprint.get_output_definitions().items():
+                if output_name not in stack_outputs:
+                    stack_outputs[output_name] = (
+                        '<inferred-change: {}.{}={}>'.format(
+                            stack.fqn, output_name,
+                            str(output_params['Value'])
+                        )
+                    )
+        except exceptions.StackDidNotChange:
+            logger.info('No changes: %s', stack.fqn)
+
+        stack.set_outputs(stack_outputs)
 
         return COMPLETE
 

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -348,7 +348,8 @@ class Blueprint(object):
                 properties.
 
         """
-        return self.template.outputs
+        return {k: output.to_dict() for k, output in
+                self.template.outputs.items()}
 
     def get_required_parameter_definitions(self):
         """Returns all template parameters that do not have a default value.

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -339,6 +339,17 @@ class Blueprint(object):
                 output[var_name] = cfn_attrs
         return output
 
+    def get_output_definitions(self):
+        """Gets the output definitions.
+
+        Returns:
+            dict: output definitions. Keys are output names, the values
+                are dicts containing key/values for various output
+                properties.
+
+        """
+        return self.template.outputs
+
     def get_required_parameter_definitions(self):
         """Returns all template parameters that do not have a default value.
 

--- a/stacker/blueprints/raw.py
+++ b/stacker/blueprints/raw.py
@@ -137,6 +137,17 @@ class RawTemplateBlueprint(Blueprint):
         """
         return get_template_params(self.to_dict())
 
+    def get_output_definitions(self):
+        """Gets the output definitions.
+
+        Returns:
+            dict: output definitions. Keys are output names, the values
+                are dicts containing key/values for various output
+                properties.
+
+        """
+        return self.to_dict().get('Outputs', {})
+
     def resolve_variables(self, provided_variables):
         """Resolve the values of the blueprint variables.
 

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -577,8 +577,7 @@ class Provider(BaseProvider):
     RECREATION_STATUSES = (
         "CREATE_FAILED",
         "ROLLBACK_FAILED",
-        "ROLLBACK_COMPLETE",
-        "REVIEW_IN_PROGRESS"
+        "ROLLBACK_COMPLETE"
     )
 
     REVIEW_STATUS = "REVIEW_IN_PROGRESS"

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -157,7 +157,7 @@ def output_full_changeset(full_changeset=None, params_diff=None,
             :func:`stacker.actions.diff.diff_dictionaries`
         answer (str, optional): predetermined answer to the prompt if it has
             already been answered or inferred.
-        fqn (str): fully qualified name of the stack
+        fqn (str, optional): fully qualified name of the stack.
 
     """
     if not answer:
@@ -198,7 +198,7 @@ def ask_for_approval(full_changeset=None, params_diff=None,
             :func:`stacker.actions.diff.diff_dictionaries`
         include_verbose (bool, optional): Boolean for whether or not to include
             the verbose option.
-        fqn (str): fully qualified name of the stack
+        fqn (str): fully qualified name of the stack.
 
     """
     approval_options = ['y', 'n']

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -1099,6 +1099,9 @@ class Provider(BaseProvider):
 
         parameters = self.params_as_dict(stack.get('Parameters', []))
 
+        if isinstance(template, str):  # handle yaml templates
+            template = parse_cloudformation_template(template)
+
         return [json.dumps(template), parameters]
 
     def get_stack_changes(self, stack, template, parameters,
@@ -1127,10 +1130,7 @@ class Provider(BaseProvider):
             _old_template, old_params = self.get_stack_info(
                 stack_details
             )
-            # needs to be loaded from string then parsed
-            old_template = parse_cloudformation_template(json.loads(
-                _old_template
-            ))
+            old_template = parse_cloudformation_template(_old_template)
             change_type = 'UPDATE'
         except exceptions.StackDoesNotExist:
             old_params = {}

--- a/stacker/tests/actions/test_diff.py
+++ b/stacker/tests/actions/test_diff.py
@@ -1,14 +1,12 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-import os
 import unittest
 
 from operator import attrgetter
 from stacker.actions.diff import (
     diff_dictionaries,
     diff_parameters,
-    normalize_json,
     DictValue
 )
 
@@ -86,77 +84,3 @@ class TestDiffParameters(unittest.TestCase):
 
         param_diffs = diff_parameters(old_params, new_params)
         self.assertEquals(param_diffs, [])
-
-
-class TestDiffFunctions(unittest.TestCase):
-    """Test functions in diff."""
-
-    def test_normalize_json(self):
-        """Ensure normalize_json parses yaml correctly."""
-        with open(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),  # noqa
-                               'fixtures',
-                               'cfn_template.yaml'), 'r') as yamlfile:
-            template = yamlfile.read()
-        normalized_template = [
-            '{\n',
-            '    "AWSTemplateFormatVersion": "2010-09-09",\n',
-            '    "Description": "TestTemplate",\n',
-            '    "Outputs": {\n',
-            '        "DummyId": {\n',
-            '            "Value": "dummy-1234"\n',
-            '        }\n',
-            '    },\n',
-            '    "Parameters": {\n',
-            '        "Param1": {\n',
-            '            "Type": "String"\n',
-            '        },\n',
-            '        "Param2": {\n',
-            '            "Default": "default",\n',
-            '            "Type": "CommaDelimitedList"\n',
-            '        }\n',
-            '    },\n',
-            '    "Resources": {\n',
-            '        "Bucket": {\n',
-            '            "Properties": {\n',
-            '                "BucketName": {\n',
-            '                    "Fn::Join": [\n',
-            '                        "-",\n',
-            '                        [\n',
-            '                            {\n',
-            '                                "Ref": "AWS::StackName"\n',
-            '                            },\n',
-            '                            {\n',
-            '                                "Ref": "AWS::Region"\n',
-            '                            }\n',
-            '                        ]\n',
-            '                    ]\n',
-            '                }\n',
-            '            },\n',
-            '            "Type": "AWS::S3::Bucket"\n',
-            '        },\n',
-            '        "Dummy": {\n',
-            '            "Type": "AWS::CloudFormation::WaitConditionHandle"\n',
-            '        }\n',
-            '    }\n',
-            '}\n'
-        ]
-        self.assertEquals(normalized_template, normalize_json(template))
-
-    def test_normalize_json_date(self):
-        """Ensure normalize_json handles objects loaded as datetime objects"""
-
-        template = """
-AWSTemplateFormatVersion: '2010-09-09'
-Description: ECS Cluster Application
-Resources:
-  ECSTaskRoleDefault:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17  # datetime.date(2012, 10, 17)
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-            Action: sts:AssumeRole"""
-        self.assertTrue(normalize_json(template))

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -31,6 +31,7 @@ from stacker.providers.aws.default import (
     create_change_set,
     summarize_params_diff,
     generate_cloudformation_args,
+    output_full_changeset
 )
 
 from stacker import exceptions
@@ -195,8 +196,7 @@ class TestMethods(unittest.TestCase):
         self.assertEqual(summarize_params_diff(only_removed_params_diff),
                          "Parameters Removed: ParamD\n")
 
-    @patch("stacker.providers.aws.default.format_params_diff")
-    def test_ask_for_approval(self, patched_format):
+    def test_ask_for_approval(self):
         get_input_path = "stacker.ui.get_raw_input"
         with patch(get_input_path, return_value="y"):
             self.assertIsNone(ask_for_approval([], [], None))
@@ -207,16 +207,15 @@ class TestMethods(unittest.TestCase):
                     ask_for_approval([], [])
 
         with patch(get_input_path, side_effect=["v", "n"]) as mock_get_input:
-            with patch("yaml.safe_dump") as mock_safe_dump:
+            with patch(
+                "stacker.providers.aws.default.output_full_changeset"
+            ) as mock_full_changeset:
                 with self.assertRaises(exceptions.CancelExecution):
                     ask_for_approval([], [], True)
-                self.assertEqual(mock_safe_dump.call_count, 1)
+                self.assertEqual(mock_full_changeset.call_count, 1)
             self.assertEqual(mock_get_input.call_count, 2)
 
-        self.assertEqual(patched_format.call_count, 0)
-
-    @patch("stacker.providers.aws.default.format_params_diff")
-    def test_ask_for_approval_with_params_diff(self, patched_format):
+    def test_ask_for_approval_with_params_diff(self):
         get_input_path = "stacker.ui.get_raw_input"
         params_diff = [
             DictValue('ParamA', None, 'new-param-value'),
@@ -231,12 +230,47 @@ class TestMethods(unittest.TestCase):
                     ask_for_approval([], params_diff)
 
         with patch(get_input_path, side_effect=["v", "n"]) as mock_get_input:
-            with patch("yaml.safe_dump") as mock_safe_dump:
+            with patch(
+                "stacker.providers.aws.default.output_full_changeset"
+            ) as mock_full_changeset:
                 with self.assertRaises(exceptions.CancelExecution):
                     ask_for_approval([], params_diff, True)
-                self.assertEqual(mock_safe_dump.call_count, 1)
+                self.assertEqual(mock_full_changeset.call_count, 1)
             self.assertEqual(mock_get_input.call_count, 2)
 
+    @patch("stacker.providers.aws.default.format_params_diff")
+    @patch('stacker.providers.aws.default.yaml.safe_dump')
+    def test_output_full_changeset(self, mock_safe_dump, patched_format):
+        get_input_path = "stacker.ui.get_raw_input"
+
+        safe_dump_counter = 0
+
+        for v in ['y', 'v', 'Y', 'V']:
+            with patch(get_input_path, return_value=v) as prompt:
+                self.assertIsNone(output_full_changeset(full_changeset=[],
+                                                        params_diff=[],
+                                                        fqn=None))
+                self.assertEqual(prompt.call_count, 1)
+                safe_dump_counter += 1
+                self.assertEqual(mock_safe_dump.call_count, safe_dump_counter)
+                self.assertEqual(patched_format.call_count, 0)
+
+        for v in ['n', 'N']:
+            with patch(get_input_path, return_value=v) as prompt:
+                output_full_changeset(full_changeset=[], params_diff=[],
+                                      answer=None, fqn=None)
+                self.assertEqual(prompt.call_count, 1)
+                self.assertEqual(mock_safe_dump.call_count, safe_dump_counter)
+                self.assertEqual(patched_format.call_count, 0)
+
+        with self.assertRaises(exceptions.CancelExecution):
+            output_full_changeset(full_changeset=[], params_diff=[],
+                                  answer='x', fqn=None)
+
+        output_full_changeset(full_changeset=[], params_diff=['mock'],
+                              answer='y', fqn=None)
+        safe_dump_counter += 1
+        self.assertEqual(mock_safe_dump.call_count, safe_dump_counter)
         self.assertEqual(patched_format.call_count, 1)
 
     def test_wait_till_change_set_complete_success(self):
@@ -566,6 +600,89 @@ class TestProviderDefaultMode(unittest.TestCase):
                 parameters=[], stack_policy=Template(body="{}"), tags=[],
             )
 
+    @patch('stacker.providers.aws.default.output_full_changeset')
+    def test_get_stack_changes_update(self, mock_output_full_cs):
+        stack_name = "MockStack"
+
+        self.stubber.add_response(
+            "create_change_set",
+            {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
+        )
+        changes = []
+        changes.append(generate_change())
+
+        self.stubber.add_response(
+            "describe_change_set",
+            generate_change_set_response(
+                status="CREATE_COMPLETE", execution_status="AVAILABLE",
+                changes=changes,
+            )
+        )
+
+        self.stubber.add_response("delete_change_set", {})
+
+        with self.stubber:
+            self.provider.get_stack_changes(
+                fqn=stack_name,
+                template=Template(url="http://fake.template.url.com/"),
+                old_parameters=[],
+                parameters=[],
+                stack_policy=None, tags=[], change_type='UPDATE'
+            )
+
+        mock_output_full_cs.assert_called_with(full_changeset=changes,
+                                               params_diff=[],
+                                               fqn=stack_name,
+                                               answer='y')
+
+    @patch('stacker.providers.aws.default.output_full_changeset')
+    def test_get_stack_changes_create(self, mock_output_full_cs):
+        stack_name = "MockStack"
+
+        self.stubber.add_response(
+            "create_change_set",
+            {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
+        )
+        changes = []
+        changes.append(generate_change())
+
+        self.stubber.add_response(
+            "describe_change_set",
+            generate_change_set_response(
+                status="CREATE_COMPLETE", execution_status="AVAILABLE",
+                changes=changes,
+            )
+        )
+
+        self.stubber.add_response("delete_change_set", {})
+
+        stack_response = {
+            "Stacks": [generate_describe_stacks_stack(
+                stack_name, stack_status='REVIEW_IN_PROGRESS'
+            )]
+        }
+        self.stubber.add_response(
+            "describe_stacks",
+            stack_response,
+            expected_params={"StackName": stack_name}
+        )
+
+        self.stubber.add_response("delete_stack", {})
+
+        with self.stubber:
+            self.provider.get_stack_changes(
+                fqn=stack_name,
+                template=Template(url="http://fake.template.url.com/"),
+                old_parameters=[],
+                parameters=[],
+                stack_policy=None, tags=[], change_type='CREATE'
+            )
+
+        mock_output_full_cs.assert_called_with(full_changeset=changes,
+                                               params_diff=[],
+                                               fqn=stack_name,
+                                               answer='y')
+
     def test_tail_stack_retry_on_missing_stack(self):
         stack_name = "SlowToCreateStack"
         stack = MagicMock(spec=Stack)
@@ -698,7 +815,8 @@ class TestProviderInteractiveMode(unittest.TestCase):
 
         patched_approval.assert_called_with(full_changeset=changes,
                                             params_diff=[],
-                                            include_verbose=True)
+                                            include_verbose=True,
+                                            fqn=stack_name)
 
         self.assertEqual(patched_approval.call_count, 1)
 
@@ -737,7 +855,8 @@ class TestProviderInteractiveMode(unittest.TestCase):
 
         patched_approval.assert_called_with(full_changeset=changes,
                                             params_diff=[],
-                                            include_verbose=True)
+                                            include_verbose=True,
+                                            fqn=stack_name)
 
         self.assertEqual(patched_approval.call_count, 1)
 
@@ -758,3 +877,42 @@ class TestProviderInteractiveMode(unittest.TestCase):
                 self.provider.select_update_method(**i[0]),
                 i[1]
             )
+
+    @patch('stacker.providers.aws.default.output_full_changeset')
+    @patch('stacker.providers.aws.default.output_summary')
+    def test_get_stack_changes_interactive(self, mock_output_summary,
+                                           mock_output_full_cs):
+        stack_name = "MockStack"
+
+        self.stubber.add_response(
+            "create_change_set",
+            {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
+        )
+        changes = []
+        changes.append(generate_change())
+
+        self.stubber.add_response(
+            "describe_change_set",
+            generate_change_set_response(
+                status="CREATE_COMPLETE", execution_status="AVAILABLE",
+                changes=changes,
+            )
+        )
+
+        self.stubber.add_response("delete_change_set", {})
+
+        with self.stubber:
+            self.provider.get_stack_changes(
+                fqn=stack_name,
+                template=Template(url="http://fake.template.url.com/"),
+                old_parameters=[],
+                parameters=[],
+                stack_policy=None, tags=[], change_type='UPDATE'
+            )
+
+        mock_output_summary.assert_called_with(stack_name, 'changes',
+                                               changes, [],
+                                               replacements_only=False)
+        mock_output_full_cs.assert_called_with(full_changeset=changes,
+                                               params_diff=[],
+                                               fqn=stack_name)


### PR DESCRIPTION
Using CFN Change Sets will give a more accurate representation of what is being changed. Akin to `terraform plan`.

# Usage

## Interactive

A summary of changes is displayed for each stack (the same as `stacker build`). The user is prompted about displaying the full changeset before moving on.

```
$ stacker diff -i dev-us-west-2.env stacks.yaml
[2019-09-12T13:21:47] Using interactive AWS provider mode.
[2019-09-12T13:21:47] Diffing stacks: stacker-tf-state
[2019-09-12T13:21:49] example-stacker-tf-state changes:
Parameters Modified: BucketName
Replacements:
- Modify TerraformStateBucket (AWS::S3::Bucket)
Changes:
- Modify ManagementPolicy (AWS::IAM::ManagedPolicy)
Show full change set? [y/n] n
```

## Default

The full change set is displayed. This example also showcases a stack (stacker-fake-resource) that is consuming the output of a previous stack (stacker-tf-state) resulting in an inferred change.

```
$ stacker diff dev-us-west-2.env stacks.yaml --region us-west-2 --replacements-only
[2019-09-12T13:30:16] Using default AWS provider mode
[2019-09-12T13:30:17] Diffing stacks: stacker-tf-state, stacker-fake-resource
[2019-09-12T13:30:19] example-stacker-tf-state full changeset:

--- Old Parameters
+++ New Parameters
******************
-BucketName = example-us-west-2-stackerdev
+BucketName = example-us-west-2-stackerdev-changed
 TableName = stacker-state-table

- ResourceChange:
    Action: Modify
    Details:
    - CausingEntity: TerraformStateBucket.Arn
      ChangeSource: ResourceAttribute
      Evaluation: Static
      Target:
        Attribute: Properties
        Name: PolicyDocument
        RequiresRecreation: Never
    LogicalResourceId: ManagementPolicy
    PhysicalResourceId: arn:aws:iam::************:policy/example-stacker-tf-state-ManagementPolicy-****
    Replacement: 'False'
    ResourceType: AWS::IAM::ManagedPolicy
    Scope:
    - Properties
  Type: Resource
- ResourceChange:
    Action: Modify
    Details:
    - ChangeSource: DirectModification
      Evaluation: Dynamic
      Target:
        Attribute: Properties
        Name: BucketName
        RequiresRecreation: Always
    - CausingEntity: BucketName
      ChangeSource: ParameterReference
      Evaluation: Static
      Target:
        Attribute: Properties
        Name: BucketName
        RequiresRecreation: Always
    LogicalResourceId: TerraformStateBucket
    PhysicalResourceId: example-us-west-2-stackerdev
    Replacement: 'True'
    ResourceType: AWS::S3::Bucket
    Scope:
    - Properties
  Type: Resource

[2019-09-12T13:30:19] stacker-tf-state: complete
[2019-09-12T13:30:22] example-stacker-fake-resource full changeset:

--- Old Parameters
+++ New Parameters
******************
-TestParameter = example-us-west-2-stackerdev
+TestParameter = <inferred-change: example-stacker-tf-state.TerraformStateBucketName={'Ref': 'TerraformStateBucket'}>

- ResourceChange:
    Action: Modify
    Details:
    - ChangeSource: DirectModification
      Evaluation: Dynamic
      Target:
        Attribute: Properties
        Name: BucketName
        RequiresRecreation: Always
    - CausingEntity: TestParameter
      ChangeSource: ParameterReference
      Evaluation: Static
      Target:
        Attribute: Properties
        Name: BucketName
        RequiresRecreation: Always
    LogicalResourceId: TestBucket
    PhysicalResourceId: example-us-west-2-stackerdev-x
    Replacement: 'True'
    ResourceType: AWS::S3::Bucket
    Scope:
    - Properties
  Type: Resource
```