### PR TITLE
Locked stacks still have requirements

### DIFF
--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -85,12 +85,6 @@ class Stack(object):
 
     @property
     def requires(self):
-        # By definition, a locked stack has no dependencies, because we won't
-        # be performing an update operation on the stack. This means, resolving
-        # outputs from dependencies is unnecessary.
-        if self.locked and not self.force:
-            return []
-
         requires = set(self.definition.requires or [])
 
         # Add any dependencies based on output lookups

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -49,32 +49,6 @@ class TestStack(unittest.TestCase):
             stack.requires,
         )
 
-    def test_stack_requires_when_locked(self):
-        definition = generate_definition(
-            base_name="vpc",
-            stack_id=1,
-            variables={
-                "Var1": "${noop fakeStack3::FakeOutput}",
-                "Var2": (
-                    "some.template.value:${output fakeStack2::FakeOutput}:"
-                    "${output fakeStack::FakeOutput}"
-                ),
-                "Var3": "${output fakeStack::FakeOutput},"
-                        "${output fakeStack2::FakeOutput}",
-            },
-            requires=["fakeStack"],
-        )
-        stack = Stack(definition=definition, context=self.context)
-
-        stack.locked = True
-        self.assertEqual(len(stack.requires), 0)
-
-        # TODO(ejholmes): When the stack is in `--force`, it's not really
-        # locked. Maybe it would be better if `stack.locked` were false when
-        # the stack is in `--force`.
-        stack.force = True
-        self.assertEqual(len(stack.requires), 2)
-
     def test_stack_requires_circular_ref(self):
         definition = generate_definition(
             base_name="vpc",


### PR DESCRIPTION
This fixes #745 . Locked stacks still have dependencies, since there
is no difference between a locked stack and an unlocked stack at
creation time.