### PR TITLE
Add link to AWS OSS Blog post

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,10 @@ Getting Started
   
   We document all functionality and features of stacker in our extensive
   reference documentation located at readthedocs_.
+
+``AWS OSS Blog``: https://aws.amazon.com/blogs/opensource/using-aws-codepipeline-and-open-source-tools-for-at-scale-infrastructure-deployment/
+
+  The AWS OSS Blog has a getting started guide using stacker with AWS CodePipeline.
   
 
 Docker


### PR DESCRIPTION
Some fine folks at AWS wrote up a thorough guide on getting started with stacker + CodePipeline. I think this would be great to include under the Getting Started section of the readme.

https://aws.amazon.com/blogs/opensource/using-aws-codepipeline-and-open-source-tools-for-at-scale-infrastructure-deployment/