### PR TITLE
Persistent graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming release
 
 - Ensure that base64 lookup codec encodes the bytes object as a string [GH-742]
+- support for persistent graphs [GH-749]
 
 ## 1.7.0 (2019-04-07)
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -5,20 +5,25 @@ Commands
 Build
 -----
 
-Build is used to create/update the stacks provided in the config file. It
-automatically figures out any dependencies between stacks, and creates them
-in parallel safely (if a stack depends on another stack, it will wait for
-that stack to be finished before updating/creating).
+Build is used to create/update the stacks_ provided in the `config file`_. It
+automatically figures out any dependencies between stacks_, and creates them
+in parallel safely (if a stack_ depends on another stack_, it will wait for
+that stack_ to be finished before updating/creating).
 
-It also provides the *--dump* flag for testing out blueprints before
+If using a `persistent graph`_, build actions more like *apply*. It will
+create/update stacks_ defined in the `config file`_ as expected but, it will
+also delete any stacks_ that exist in the `persistent graph`_ but are no longer
+present in the `config file`_.
+
+It also provides the **--dump** flag for testing out blueprints_ before
 pushing them up into CloudFormation.
-Even then, some errors might only be noticed after first submitting a stack,
+Even then, some errors might only be noticed after first submitting a stack_,
 at which point it can no longer be updated by Stacker.
 When that situation is detected in interactive mode, you will be prompted to
-delete and re-create the stack, so that you don't need to do it manually in the
-AWS console.
+delete and re-create the stack_, so that you don't need to do it manually in
+the AWS console.
 If that behavior is also desired in non-interactive mode, enable the
-*--recreate-failed* flag.
+**--recreate-failed** flag.
 
 ::
 
@@ -32,6 +37,9 @@ If that behavior is also desired in non-interactive mode, enable the
   is smart enough to figure out if anything (the template or parameters) have
   changed for a given stack. If nothing has changed, stacker will correctly skip
   executing anything against the stack.
+
+  If using a persistent graph, Stacker will also delete any stacks that exist
+  in the persistent graph but are no longer present in the config file.
 
   positional arguments:
     environment           Path to a simple `key: value` pair environment file.
@@ -79,9 +87,9 @@ Destroy
 -------
 
 Destroy handles the tearing down of CloudFormation stacks defined in the
-config file. It figures out any dependencies that may exist, and destroys
-the stacks in the correct order (in parallel if all dependent stacks have
-already been destroyed).
+`config file`_ and `persistent graph`_ (if enabled). It figures out any
+dependencies that may exist, and destroys the stacks_ in the correct order
+(in parallel if all dependent stacks have already been destroyed).
 
 ::
 
@@ -90,9 +98,10 @@ already been destroyed).
                          [--replacements-only] [-f] [--stacks STACKNAME] [-t]
                          environment config
 
-  Destroys CloudFormation stacks based on the given config. Stacker will
-  determine the order in which stacks should be destroyed based on any manual
-  requirements they specify or output values they rely on from other stacks.
+  Destroys CloudFormation stacks based on the given config and persistent graph
+  (if enabled). Stacker will determine the order in which stacks should be
+  destroyed based on any manual requirements they specify or output values they
+  rely on from other stacks.
 
   positional arguments:
     environment           Path to a simple `key: value` pair environment file.
@@ -103,7 +112,7 @@ already been destroyed).
     config                The config file where stack configuration is located.
                           Must be in yaml format. If `-` is provided, then the
                           config will be read from stdin.
-                          
+
   optional arguments:
     -h, --help            show this help message and exit
     -e ENV=VALUE, --env ENV=VALUE
@@ -129,55 +138,6 @@ already been destroyed).
                           than once. If not specified then stacker will work on
                           all stacks in the config file.
     -t, --tail            Tail the CloudFormation logs while working with stacks
-
-Info
-----
-
-
-Info displays information on the CloudFormation stacks based on the given
-config.
-
-::
-
-  # stacker info -h
-  usage: stacker info [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
-                      [--replacements-only] [--stacks STACKNAME]
-                      environment config
-
-  Gets information on the CloudFormation stacks based on the given config.
-
-  positional arguments:
-    environment           Path to a simple `key: value` pair environment file.
-                          The values in the environment file can be used in the
-                          stack config as if it were a string.Template type:
-                          https://docs.python.org/2/library/string.html
-                          #template-strings. Must define at least a "namespace".
-    config                The config file where stack configuration is located.
-                          Must be in yaml format. If `-` is provided, then the
-                          config will be read from stdin.
-
-  optional arguments:
-    -h, --help            show this help message and exit
-    -e ENV=VALUE, --env ENV=VALUE
-                          Adds environment key/value pairs from the command
-                          line. Overrides your environment file settings. Can be
-                          specified more than once.
-    -r REGION, --region REGION
-                          The AWS region to launch in.
-    -v, --verbose         Increase output verbosity. May be specified up to
-                          twice.
-    -i, --interactive     Enable interactive mode. If specified, this will use
-                          the AWS interactive provider, which leverages
-                          Cloudformation Change Sets to display changes before
-                          running cloudformation templates. You'll be asked if
-                          you want to execute each change set. If you only want
-                          to authorize replacements, run with "--replacements-
-                          only" as well.
-    --replacements-only   If interactive mode is enabled, stacker will only
-                          prompt to authorize replacements.
-    --stacks STACKNAME    Only work on the stacks given. Can be specified more
-                          than once. If not specified then stacker will work on
-                          all stacks in the config file.
 
 Diff
 ----
@@ -233,3 +193,107 @@ possible, but it should give a good idea if anything has changed.
     --stacks STACKNAME    Only work on the stacks given. Can be specified more
                           than once. If not specified then stacker will work on
                           all stacks in the config file.
+
+Graph
+-----
+
+Prints the the relationships between steps as a `graph <terminology.html#graph>`_.
+
+::
+
+  positional arguments:
+    environment           Path to a simple `key: value` pair environment file.
+                          The values in the environment file can be used in the
+                          stack config as if it were a string.Template type:
+                          https://docs.python.org/2/library/string.html
+                          #template-strings.
+    config                The config file where stack configuration is located.
+                          Must be in yaml format. If `-` is provided, then the
+                          config will be read from stdin.
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    -e ENV=VALUE, --env ENV=VALUE
+                          Adds environment key/value pairs from the command
+                          line. Overrides your environment file settings. Can be
+                          specified more than once.
+    -r REGION, --region REGION
+                          The default AWS region to use for all AWS API calls.
+    -p PROFILE, --profile PROFILE
+                          The default AWS profile to use for all AWS API calls.
+                          If not specified, the default will be according to htt
+                          p://boto3.readthedocs.io/en/latest/guide/configuration
+                          .html.
+    -v, --verbose         Increase output verbosity. May be specified up to
+                          twice.
+    -i, --interactive     Enable interactive mode. If specified, this will use
+                          the AWS interactive provider, which leverages
+                          Cloudformation Change Sets to display changes before
+                          running cloudformation templates. You'll be asked if
+                          you want to execute each change set. If you only want
+                          to authorize replacements, run with "--replacements-
+                          only" as well.
+    --replacements-only   If interactive mode is enabled, stacker will only
+                          prompt to authorize replacements.
+    --recreate-failed     Destroy and re-create stacks that are stuck in a
+                          failed state from an initial deployment when updating.
+    -f {json,dot}, --format {json,dot}
+                          The format to print the graph in.
+    --reduce              When provided, this will create a graph with less
+                          edges, by performing a transitive reduction on the
+                          underlying graph. While this will produce a less noisy
+                          graph, it is slower.
+
+Info
+----
+
+Info displays information on the CloudFormation stacks based on the given
+config.
+
+::
+
+  # stacker info -h
+  usage: stacker info [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
+                      [--replacements-only] [--stacks STACKNAME]
+                      environment config
+
+  Gets information on the CloudFormation stacks based on the given config.
+
+  positional arguments:
+    environment           Path to a simple `key: value` pair environment file.
+                          The values in the environment file can be used in the
+                          stack config as if it were a string.Template type:
+                          https://docs.python.org/2/library/string.html
+                          #template-strings. Must define at least a "namespace".
+    config                The config file where stack configuration is located.
+                          Must be in yaml format. If `-` is provided, then the
+                          config will be read from stdin.
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    -e ENV=VALUE, --env ENV=VALUE
+                          Adds environment key/value pairs from the command
+                          line. Overrides your environment file settings. Can be
+                          specified more than once.
+    -r REGION, --region REGION
+                          The AWS region to launch in.
+    -v, --verbose         Increase output verbosity. May be specified up to
+                          twice.
+    -i, --interactive     Enable interactive mode. If specified, this will use
+                          the AWS interactive provider, which leverages
+                          Cloudformation Change Sets to display changes before
+                          running cloudformation templates. You'll be asked if
+                          you want to execute each change set. If you only want
+                          to authorize replacements, run with "--replacements-
+                          only" as well.
+    --replacements-only   If interactive mode is enabled, stacker will only
+                          prompt to authorize replacements.
+    --stacks STACKNAME    Only work on the stacks given. Can be specified more
+                          than once. If not specified then stacker will work on
+                          all stacks in the config file.
+
+.. _blueprints: terminology.html#blueprint
+.. _config file: terminology.html#config
+.. _persistent graph: config.html#persistent-graph
+.. _stack: terminology.html#stack
+.. _stacks: terminology.html#stack

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -2,6 +2,7 @@
 Terminology
 ===========
 
+
 blueprint
 =========
 
@@ -10,17 +11,64 @@ blueprint
 A python class that is responsible for creating a CloudFormation template.
 Usually this is built using troposphere_.
 
+
 config
 ======
 
+.. _config file:
+
 A YAML config file that defines the `stack definitions`_ for all of the
 stacks you want stacker to manage.
+
+
+context
+=======
+
+Context is responsible for translating the values passed in via the
+command line and specified in the config_ to stacks_.
+
+.. _troposphere: https://github.com/cloudtools/troposphere
+.. _CloudFormation Parameters: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
+
 
 environment
 ===========
 
 A set of variables that can be used inside the config, allowing you to
 slightly adjust configs based on which environment you are launching.
+
+
+graph
+=====
+
+A mapping of **object name** to **set/list of dependencies**.
+
+A graph is constructed for each execution of Stacker from the contents of the
+config_ file.
+
+Example
+-------
+
+.. code-block:: json
+
+    {
+        "stack1": [],
+        "stack2": [
+            "stack1"
+        ]
+    }
+
+- **stack1** depends on nothing.
+- **stack2** depends on **stack1**
+
+
+lookup
+======
+
+A method for expanding values in the config_ at build time. By default
+lookups are used to reference Output values from other stacks_ within the
+same namespace_.
+
 
 namespace
 =========
@@ -29,14 +77,29 @@ A way to uniquely identify a stack. Used to determine the naming of many
 things, such as the S3 bucket where compiled templates are stored, as well
 as the prefix for stack names.
 
-stack definition
+
+output
+======
+
+A CloudFormation Template concept. Stacks can output values, allowing easy
+access to those values. Often used to export the unique ID's of resources that
+templates create. Stacker makes it simple to pull outputs from one stack and
+then use them as a variable_ in another stack.
+
+
+persistent graph
 ================
 
-.. _stack definitions:
+A graph_ that is persisted between Stacker executions. It is stored in in the
+Stack `S3 bucket <config.html#s3-bucket>`_.
 
-Defines the stack_ you want to build, usually there are multiple of these in
-the config_. It also defines the variables_ to be used when building the
-stack_.
+
+provider
+========
+
+Provider that supports provisioning rendered blueprints_. By default, an
+AWS provider is used.
+
 
 stack
 =====
@@ -47,13 +110,16 @@ The resulting stack of resources that is created by CloudFormation when it
 executes a template. Each stack managed by stacker is defined by a
 `stack definition`_ in the config_.
 
-output
-======
 
-A CloudFormation Template concept. Stacks can output values, allowing easy
-access to those values. Often used to export the unique ID's of resources that
-templates create. Stacker makes it simple to pull outputs from one stack and
-then use them as a variable_ in another stack.
+stack definition
+================
+
+.. _stack definitions:
+
+Defines the stack_ you want to build, usually there are multiple of these in
+the config_. It also defines the variables_ to be used when building the
+stack_.
+
 
 variable
 ========
@@ -63,24 +129,3 @@ variable
 Dynamic variables that are passed into stacks when they are being built.
 Variables are defined within the config_.
 
-lookup
-======
-
-A method for expanding values in the config_ at build time. By default
-lookups are used to reference Output values from other stacks_ within the
-same namespace_.
-
-provider
-========
-
-Provider that supports provisioning rendered blueprints_. By default, an
-AWS provider is used.
-
-context
-=======
-
-Context is responsible for translating the values passed in via the
-command line and specified in the config_ to stacks_.
-
-.. _troposphere: https://github.com/cloudtools/troposphere
-.. _CloudFormation Parameters: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ install_requires = [
     "gitpython>=2.0,<3.0",
     "jinja2>=2.7,<3.0",
     "schematics>=2.0.1,<2.1.0",
-    "formic2",
-    "python-dateutil>=2.0,<3.0",
+    "formic2"
 ]
 
 setup_requires = ['pytest-runner']

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -110,6 +110,8 @@ class BaseAction(object):
 
     """
 
+    DESCRIPTION = 'Base action'
+
     def __init__(self, context, provider_builder=None, cancel=None):
         self.context = context
         self.provider_builder = provider_builder
@@ -118,7 +120,8 @@ class BaseAction(object):
         self.bucket_region = context.config.stacker_bucket_region
         if not self.bucket_region and provider_builder:
             self.bucket_region = provider_builder.region
-        self.s3_conn = get_session(self.bucket_region).client('s3')
+        self.s3_conn = (getattr(self.context, 's3_conn', None) or
+                        get_session(self.bucket_region).client('s3'))
 
     @property
     def _stack_action(self):

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -44,6 +44,7 @@ class Stacker(BaseCommand):
         options.context = Context(
             environment=options.environment,
             config=self.config,
+            region=options.region,
             # Allow subcommands to provide any specific kwargs to the Context
             # that it wants.
             **options.get_context_kwargs(options)

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -4,6 +4,9 @@ Stacker is smart enough to figure out if anything (the template or parameters)
 have changed for a given stack. If nothing has changed, stacker will correctly
 skip executing anything against the stack.
 
+If using a persistent graph, Stacker will also delete any stacks that exist
+in the persistent graph but are no longer present in the config file.
+
 """
 from __future__ import print_function
 from __future__ import division

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -1,4 +1,5 @@
-"""Destroys CloudFormation stacks based on the given config.
+"""Destroys CloudFormation stacks based on the given config and persistent
+graph (if enabled).
 
 Stacker will determine the order in which stacks should be destroyed based on
 any manual requirements they specify or output values they rely on from other

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -402,6 +402,8 @@ class Config(Model):
 
     stacker_bucket_region = StringType(serialize_when_none=False)
 
+    persistent_graph_key = StringType(serialize_when_none=False)
+
     stacker_cache_dir = StringType(serialize_when_none=False)
 
     sys_path = StringType(serialize_when_none=False)

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -3,11 +3,20 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import object
 import collections
+import json
 import logging
 
 from stacker.config import Config
+from .exceptions import (PersistentGraphCannotLock,
+                         PersistentGraphCannotUnlock,
+                         PersistentGraphLocked,
+                         PersistentGraphLockCodeMissmatch,
+                         PersistentGraphUnlocked)
+from .plan import Graph
+from .session_cache import get_session
 from .stack import Stack
 from .target import Target
+from .util import ensure_s3_bucket
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +51,7 @@ class Context(object):
             usually all stacks defined in the config will be operated on.
         config (:class:`stacker.config.Config`): The stacker configuration
             being operated on.
+        region (str): Name of an AWS region if provided as a CLI argument.
         force_stacks (list): A list of stacks to force work on. Used to work
             on locked stacks.
 
@@ -50,12 +60,43 @@ class Context(object):
     def __init__(self, environment=None,
                  stack_names=None,
                  config=None,
+                 region=None,
                  force_stacks=None):
-        self.environment = environment
-        self.stack_names = stack_names or []
+        self._bucket_name = None
+        self._persistent_graph = None
+        self._persistent_graph_lock_code = None
+        self._persistent_graph_lock_tag = 'stacker_lock_code'
+        self._s3_bucket_verified = None
+        self._upload_to_s3 = None
+        self.bucket_region = config.stacker_bucket_region or region
         self.config = config or Config()
+        self.environment = environment
         self.force_stacks = force_stacks or []
         self.hook_data = {}
+        self.s3_conn = get_session(self.bucket_region).client('s3')
+        self.stack_names = stack_names or []
+
+    @property
+    def _base_fqn(self):
+        return self.namespace.replace(".", "-").lower()
+
+    @property
+    def _persistent_graph_tags(self):
+        """Cached dict of tags on the persistent graph object.
+
+        Returns:
+            (Dict[str, str])
+
+        """
+        try:
+            return {t['Key']: t['Value'] for t in
+                    self.s3_conn.get_object_tagging(
+                    **self.persistent_graph_location
+                    ).get('TagSet', {})}
+        except self.s3_conn.exceptions.NoSuchKey:
+            logger.debug('Persistant graph object does not exist in S3; '
+                         'could not get tags')
+            return {}
 
     @property
     def namespace(self):
@@ -77,32 +118,130 @@ class Context(object):
 
     @property
     def bucket_name(self):
-        if not self.upload_templates_to_s3:
+        """Stacker bucket name."""
+        if not self.upload_to_s3:
             return None
-
-        return self.config.stacker_bucket \
-            or "stacker-%s" % (self.get_fqn(),)
+        if not self._bucket_name:
+            self._bucket_name = self.config.stacker_bucket \
+                or "stacker-%s" % (self.get_fqn())
+        return self._bucket_name
 
     @property
-    def upload_templates_to_s3(self):
-        # Don't upload stack templates to S3 if `stacker_bucket` is explicitly
-        # set to an empty string.
-        if self.config.stacker_bucket == '':
-            logger.debug("Not uploading templates to s3 because "
-                         "`stacker_bucket` is explicity set to an "
-                         "empty string")
-            return False
+    def mappings(self):
+        return self.config.mappings or {}
 
-        # If no namespace is specificied, and there's no explicit stacker
-        # bucket specified, don't upload to s3. This makes sense because we
-        # can't realistically auto generate a stacker bucket name in this case.
-        if not self.namespace and not self.config.stacker_bucket:
-            logger.debug("Not uploading templates to s3 because "
-                         "there is no namespace set, and no "
-                         "stacker_bucket set")
-            return False
+    @property
+    def persistent_graph(self):
+        """Persistent graph object if one is to be used.
 
+        Will create an "empty" object in S3 if one is not found.
+
+        Returns:
+            (:class:`stacker.plan.Graph`)
+
+        """
+        if not self.persistent_graph_location:
+            return None
+
+        content = '{}'
+
+        if not self._persistent_graph:
+            if self.s3_bucket_verified:
+                try:
+                    logger.debug('Getting persistent graph from s3:\n%s',
+                                 json.dumps(self.persistent_graph_location,
+                                            indent=4))
+                    content = self.s3_conn.get_object(
+                        ResponseContentType='application/json',
+                        **self.persistent_graph_location
+                    )['Body'].read().decode('utf-8')
+                except self.s3_conn.exceptions.NoSuchKey:
+                    logger.info('Persistant graph object does not exist '
+                                'in S3; creating one now.')
+                    self.s3_conn.put_object(
+                        Body=content,
+                        ServerSideEncryption='AES256',
+                        ACL='bucket-owner-full-control',
+                        ContentType='application/json',
+                        **self.persistent_graph_location
+                    )
+            self.persistent_graph = json.loads(content)
+
+        return self._persistent_graph
+
+    @persistent_graph.setter
+    def persistent_graph(self, graph_dict):
+        """Load a persistent graph dict as a :class:`stacker.plan.Graph`."""
+        self._persistent_graph = Graph.from_dict(graph_dict, self)
+
+    @property
+    def persistent_graph_location(self):
+        """Location of the persistent graph in s3.
+
+        Returns:
+            (Dict[str, str]) Bucket and Key for the object in S3.
+
+        """
+        if not self.upload_to_s3 or not self.config.persistent_graph_key:
+            return {}
+
+        return {
+            'Bucket': self.bucket_name,
+            'Key': 'persistent_graphs/{namespace}/{key}'.format(
+                namespace=self.config.namespace,
+                key=(self.config.persistent_graph_key + '.json' if not
+                     self.config.persistent_graph_key.endswith('.json')
+                     else self.config.persistent_graph_key)
+            )
+        }
+
+    @property
+    def persistent_graph_lock_code(self):
+        """Code used to lock the persistent graph S3 object.
+
+        Returns:
+            (Optional[str])
+
+        """
+        if not self._persistent_graph_lock_code:
+            self._persistent_graph_lock_code = self._persistent_graph_tags.get(
+                self._persistent_graph_lock_tag
+            )
+        return self._persistent_graph_lock_code
+
+    @property
+    def persistent_graph_locked(self):
+        """Check if persistent graph is locked.
+
+        Returns:
+            (bool)
+
+        """
+        if not self.persistent_graph:
+            return False
+        if not self.persistent_graph_lock_code:
+            return False
         return True
+
+    @property
+    def s3_bucket_verified(self):
+        """Check Stacker bucket exists and you have access.
+
+        If the Stacker bucket does not exist, will try to create one.
+
+        Returns:
+            (bool)
+
+        """
+        if not self._s3_bucket_verified and self.bucket_name:
+            ensure_s3_bucket(self.s3_conn,
+                             self.bucket_name,
+                             self.bucket_region,
+                             persist_graph=(True if
+                                            self.persistent_graph_location
+                                            else False))
+            self._s3_bucket_verified = True
+        return self._s3_bucket_verified
 
     @property
     def tags(self):
@@ -114,12 +253,31 @@ class Context(object):
         return {}
 
     @property
-    def _base_fqn(self):
-        return self.namespace.replace(".", "-").lower()
+    def upload_to_s3(self):
+        """Check if S3 should be used for caching/persistent graph.
 
-    @property
-    def mappings(self):
-        return self.config.mappings or {}
+        Returns:
+            (bool)
+
+        """
+        if not self._upload_to_s3:
+            # Don't upload stack templates to S3 if `stacker_bucket` is
+            # explicitly set to an empty string.
+            if self.config.stacker_bucket == '':
+                logger.debug("Not uploading to s3 because `stacker_bucket` "
+                             "is explicitly set to an empty string")
+                return False
+
+            # If no namespace is specificied, and there's no explicit
+            # stacker bucket specified, don't upload to s3. This makes
+            # sense because we can't realistically auto generate a stacker
+            # bucket name in this case.
+            if not self.namespace and not self.config.stacker_bucket:
+                logger.debug("Not uploading to s3 because there is no "
+                             "namespace set, and no stacker_bucket set")
+                return False
+
+        return True
 
     def _get_stack_definitions(self):
         return self.config.stacks
@@ -183,6 +341,80 @@ class Context(object):
         """
         return get_fqn(self._base_fqn, self.namespace_delimiter, name)
 
+    def lock_persistent_graph(self, lock_code):
+        """Locks the persistent graph in s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`stacker.exceptions.PersistentGraphLocked`
+            :class:`stacker.exceptions.PersistentGraphCannotLock`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        if self.persistent_graph_locked:
+            raise PersistentGraphLocked
+
+        try:
+            self.s3_conn.put_object_tagging(
+                Tagging={'TagSet': [
+                    {'Key': self._persistent_graph_lock_tag,
+                     'Value': lock_code}
+                ]},
+                **self.persistent_graph_location
+            )
+            logger.info('Locked persistent graph "%s" with lock ID "%s".',
+                        '/'.join([self.persistent_graph_location['Bucket'],
+                                  self.persistent_graph_location['Key']]),
+                        lock_code)
+        except self.s3_conn.exceptions.NoSuchKey:
+            raise PersistentGraphCannotLock('s3 object does not exist')
+
+    def put_persistent_graph(self, lock_code):
+        """Upload persistent graph to s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`stacker.exceptions.PersistentGraphUnlocked`
+            :class:`stacker.exceptions.PersistentGraphLockCodeMissmatch`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        if not self.persistent_graph_locked:
+            raise PersistentGraphUnlocked(
+                reason='It must be locked by the current session to be '
+                       'updated.'
+            )
+
+        if self.persistent_graph_lock_code != lock_code:
+            raise PersistentGraphLockCodeMissmatch(
+                lock_code, self.persistent_graph_lock_code
+            )
+
+        if not self.persistent_graph.to_dict():
+            self.s3_conn.delete_object(**self.persistent_graph_location)
+            logger.debug('Removed empty persistent graph object from S3')
+            return
+
+        self.s3_conn.put_object(
+            Body=self.persistent_graph.dumps(4),
+            ServerSideEncryption='AES256',
+            ACL='bucket-owner-full-control',
+            ContentType='application/json',
+            Tagging='{}={}'.format(self._persistent_graph_lock_tag,
+                                   lock_code),
+            **self.persistent_graph_location
+        )
+        logger.debug('Persistent graph updated:\n%s',
+                     self.persistent_graph.dumps(indent=4))
+
     def set_hook_data(self, key, data):
         """Set hook data for the given key.
 
@@ -202,3 +434,44 @@ class Context(object):
                            "must have a unique data_key.", key)
 
         self.hook_data[key] = data
+
+    def unlock_persistent_graph(self, lock_code):
+        """Unlocks the persistent graph in s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`stacker.exceptions.PersistentGraphCannotUnlock`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        logger.debug('Unlocking persistent graph "%s".',
+                     self.persistent_graph_location)
+
+        if not self.persistent_graph_locked:
+            raise PersistentGraphCannotUnlock(PersistentGraphUnlocked(
+                reason='It must be locked by the current session to be '
+                       'unlocked.'
+            ))
+
+        if self.persistent_graph_lock_code == lock_code:
+            try:
+                self.s3_conn.delete_object_tagging(
+                    **self.persistent_graph_location
+                )
+            except self.s3_conn.exceptions.NoSuchKey:
+                pass
+            self._persistent_graph_lock_code = None
+            logger.info('Unlocked persistent graph "%s".',
+                        '/'.join([self.persistent_graph_location['Bucket'],
+                                  self.persistent_graph_location['Key']]))
+            return True
+        raise PersistentGraphCannotUnlock(
+            PersistentGraphLockCodeMissmatch(
+                lock_code,
+                self.persistent_graph_lock_code
+            )
+        )

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -68,8 +68,8 @@ class Context(object):
         self._persistent_graph_lock_tag = 'stacker_lock_code'
         self._s3_bucket_verified = None
         self._upload_to_s3 = None
-        self.bucket_region = config.stacker_bucket_region or region
         self.config = config or Config()
+        self.bucket_region = self.config.stacker_bucket_region or region
         self.environment = environment
         self.force_stacks = force_stacks or []
         self.hook_data = {}
@@ -91,8 +91,7 @@ class Context(object):
         try:
             return {t['Key']: t['Value'] for t in
                     self.s3_conn.get_object_tagging(
-                    **self.persistent_graph_location
-                    ).get('TagSet', {})}
+                        **self.persistent_graph_location).get('TagSet', {})}
         except self.s3_conn.exceptions.NoSuchKey:
             logger.debug('Persistant graph object does not exist in S3; '
                          'could not get tags')
@@ -140,12 +139,12 @@ class Context(object):
             (:class:`stacker.plan.Graph`)
 
         """
-        if not self.persistent_graph_location:
-            return None
-
-        content = '{}'
-
         if not self._persistent_graph:
+            if not self.persistent_graph_location:
+                return None
+
+            content = '{}'
+
             if self.s3_bucket_verified:
                 try:
                     logger.debug('Getting persistent graph from s3:\n%s',
@@ -203,7 +202,8 @@ class Context(object):
             (Optional[str])
 
         """
-        if not self._persistent_graph_lock_code:
+        if (not self._persistent_graph_lock_code and
+                self.persistent_graph_location):
             self._persistent_graph_lock_code = self._persistent_graph_tags.get(
                 self._persistent_graph_lock_tag
             )

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -273,3 +273,66 @@ class GraphError(Exception):
             "as a dependency of '%s': %s"
         ) % (dependency, stack, str(exception))
         super(GraphError, self).__init__(message)
+
+
+class PersistentGraphCannotLock(Exception):
+    """Raised when the persistent graph in S3 cannot be locked."""
+
+    def __init__(self, reason):
+        """Instantiate class."""
+        message = "Could not lock persistent graph; %s" % reason
+        super(PersistentGraphCannotLock, self).__init__(message)
+
+
+class PersistentGraphCannotUnlock(Exception):
+    """Raised when the persistent graph in S3 cannot be unlocked."""
+
+    def __init__(self, reason):
+        """Instantiate class."""
+        message = "Could not unlock persistent graph; %s" % reason
+        super(PersistentGraphCannotUnlock, self).__init__(message)
+
+
+class PersistentGraphLocked(Exception):
+    """
+    Raised when the persistent graph in S3 is lock and an action requiring
+    it to be unlocked is attempted.
+    """
+
+    def __init__(self, message=None, reason=None):
+        """Instantiate class."""
+        if not message:
+            message = ("Persistant graph is locked. {}".format(
+                reason or ("This action requires the graph to be "
+                           "unlocked to be executed.")
+            ))
+        super(PersistentGraphLocked, self).__init__(message)
+
+
+class PersistentGraphLockCodeMissmatch(Exception):
+    """
+    Raised when the provided persistent graph lock code does not match
+    the s3 object lock code.
+    """
+
+    def __init__(self, provided_code, s3_code):
+        """Instantiate class."""
+        message = ("The provided lock code '%s' does not match the S3 "
+                   "object lock code '%s'" % (provided_code, s3_code))
+        super(PersistentGraphLockCodeMissmatch, self).__init__(message)
+
+
+class PersistentGraphUnlocked(Exception):
+    """
+    Raised when the persistent graph in S3 is unlock and an action
+    requiring it to be locked is attempted.
+    """
+
+    def __init__(self, message=None, reason=None):
+        """Instantiate class."""
+        if not message:
+            message = ("Persistant graph is unlocked. {}".format(
+                reason or ("This action requires the graph to be "
+                           "locked to be executed.")
+            ))
+        super(PersistentGraphLocked, self).__init__(message)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -335,4 +335,4 @@ class PersistentGraphUnlocked(Exception):
                 reason or ("This action requires the graph to be "
                            "locked to be executed.")
             ))
-        super(PersistentGraphLocked, self).__init__(message)
+        super(PersistentGraphUnlocked, self).__init__(message)

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -371,7 +371,7 @@ class Graph(object):
         """Remove a step from the graph.
 
         Args:
-            step: (:class:`Step`): The step to remove from the graph.
+            step (:class:`Step`): The step to remove from the graph.
             default (Any): Returned if the step could not be popped
 
         Returns:

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -3,19 +3,23 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import object
 import os
+import json
 import logging
 import time
 import uuid
 import threading
 
-from .util import stack_template_key_name
+from .util import stack_template_key_name, merge_map
 from .exceptions import (
+    CancelExecution,
     GraphError,
     PlanFailed,
+    PersistentGraphLocked
 )
 from .ui import ui
 from .dag import DAG, DAGValidationError, walk
 from .status import (
+    SkippedStatus,
     FailedStatus,
     PENDING,
     SUBMITTED,
@@ -33,6 +37,21 @@ COLOR_CODES = {
 }
 
 
+def json_serial(obj):
+    """Serialize json.
+
+    Args:
+        obj (Any): A python object.
+
+    Example:
+        json.dumps(data, default=json_serial)
+
+    """
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError
+
+
 def log_step(step):
     msg = "%s: %s" % (step, step.status.name)
     if step.status.reason:
@@ -41,18 +60,39 @@ def log_step(step):
     ui.info(msg, extra={"color": color_code})
 
 
+def merge_graphs(graph1, graph2):
+    """Combine two Graphs into one, retaining steps.
+
+    Args:
+        graph1 (:class:`Graph`): Graph that ``graph2`` will
+            be merged into.
+        graph2 (:class:`Graph`): Graph that will be merged
+            into ``graph1``.
+
+    Returns:
+        (:class:`Graph`) A combined graph.
+
+    """
+    merged_graph_dict = merge_map(graph1.to_dict().copy(),
+                                  graph2.to_dict())
+    steps = [graph1.steps.get(name, graph2.steps.get(name))
+             for name in merged_graph_dict.keys()]
+    return Graph.from_steps(steps)
+
+
 class Step(object):
     """State machine for executing generic actions related to stacks.
+
     Args:
-        stack (:class:`stacker.stack.Stack`): the stack associated
-            with this step
-        fn (func): the function to run to execute the step. This function will
-            be ran multiple times until the step is "done".
-        watch_func (func): an optional function that will be called to "tail"
-            the step action.
+        stack (:class:`Stack`): the stack associated with this step.
+        fn (Callable): the function to run to execute the step. This
+            function will be ran multiple times until the step is "done".
+        watch_func (Callable): an optional function that will be called
+            to "tail" the step action.
+
     """
 
-    def __init__(self, stack, fn, watch_func=None):
+    def __init__(self, stack, fn=None, watch_func=None):
         self.stack = stack
         self.status = PENDING
         self.last_updated = time.time()
@@ -91,9 +131,11 @@ class Step(object):
     def _run_once(self):
         try:
             status = self.fn(self.stack, status=self.status)
-        except Exception as e:
-            logger.exception(e)
-            status = FailedStatus(reason=str(e))
+        except CancelExecution:
+            status = SkippedStatus('canceled execution')
+        except Exception as err:
+            logger.exception(err)
+            status = FailedStatus(reason=str(err))
         self.set_status(status)
         return status
 
@@ -166,58 +208,60 @@ class Step(object):
         """A shortcut for set_status(SUBMITTED)"""
         self.set_status(SUBMITTED)
 
+    @classmethod
+    def from_stack_name(cls, stack_name, context, requires=None, fn=None,
+                        watch_func=None):
+        """Create a step using only a stack name.
 
-def build_plan(description, graph,
-               targets=None, reverse=False):
-    """Builds a plan from a list of steps.
-    Args:
-        description (str): an arbitrary string to
-            describe the plan.
-        graph (:class:`Graph`): a list of :class:`Graph` to execute.
-        targets (list): an optional list of step names to filter the graph to.
-            If provided, only these steps, and their transitive dependencies
-            will be executed. If no targets are specified, every node in the
-            graph will be executed.
-        reverse (bool): If provided, the graph will be walked in reverse order
-            (dependencies last).
-    """
+        Args:
+            stack_name (str): Name of a CloudFormation stack.
+            context (:class:`stacker.context.Context`): Context object.
+                Required to initialize a "fake" :class:`stacker.stack.Stack`.
+            requires (List[str]): Stacks that this stack depends on.
+            fn (Callable): The function to run to execute the step.
+                This function will be ran multiple times until the step
+                is "done".
+            watch_func (Callable): an optional function that will be
+                called to "tail" the step action.
 
-    # If we want to execute the plan in reverse (e.g. Destroy), transpose the
-    # graph.
-    if reverse:
-        graph = graph.transposed()
+        Returns:
+            (:class:`Step`)
 
-    # If we only want to build a specific target, filter the graph.
-    if targets:
-        nodes = []
-        for target in targets:
-            for k, step in graph.steps.items():
-                if step.name == target:
-                    nodes.append(step.name)
-        graph = graph.filtered(nodes)
+        """
+        from stacker.config import Stack as stack_conf
+        from stacker.stack import Stack
 
-    return Plan(description=description, graph=graph)
+        stack_def = stack_conf({'name': stack_name,
+                                'requires': requires or []})
+        stack = Stack(stack_def, context)
+        return cls(stack, fn=fn, watch_func=watch_func)
 
+    @classmethod
+    def from_persistent_graph(cls, graph_dict, context, fn=None,
+                              watch_func=None):
+        """Create a steps for a persistent graph dict.
 
-def build_graph(steps):
-    """Builds a graph of steps.
-    Args:
-        steps (list): a list of :class:`Step` objects to execute.
-    """
+        Args:
+            graph_dict (Dict[str, List[str]]): A graph dict.
+            context (:class:`stacker.context.Context`): Context object.
+                Required to initialize a "fake" :class:`stacker.stack.Stack`.
+            requires (List[str]): Stacks that this stack depends on.
+            fn (Callable): The function to run to execute the step.
+                This function will be ran multiple times until the step
+                is "done".
+            watch_func (Callable): an optional function that will be
+                called to "tail" the step action.
 
-    graph = Graph()
+        Returns:
+            (List[:class:`Step`])
 
-    for step in steps:
-        graph.add_step(step)
+        """
+        steps = []
 
-    for step in steps:
-        for dep in step.requires:
-            graph.connect(step.name, dep)
-
-        for parent in step.required_by:
-            graph.connect(parent, step.name)
-
-    return graph
+        for name, requires in graph_dict.items():
+            steps.append(cls.from_stack_name(name, context, requires,
+                                             fn, watch_func))
+        return steps
 
 
 class Graph(object):
@@ -238,18 +282,104 @@ class Graph(object):
     >>> dag.connect(a, b)
 
     Args:
-        steps (list): an optional list of :class:`Step` objects to execute.
+        steps (List[:class:`Step`]): an optional list of :class:`Step`
+            objects to execute.
         dag (:class:`stacker.dag.DAG`): an optional :class:`stacker.dag.DAG`
             object. If one is not provided, a new one will be initialized.
+
     """
+
+    def __str__(self):
+        return self.dumps()
 
     def __init__(self, steps=None, dag=None):
         self.steps = steps or {}
         self.dag = dag or DAG()
 
-    def add_step(self, step):
+    def add_step(self, step, add_dependencies=False, add_dependants=False):
+        """Add a step to the graph.
+
+        Args:
+            step (:class:`Step`): The step to be added.
+            add_dependencies (bool): Connect steps that need to be completed
+                before this step.
+            add_dependants (bool): Connect steps that require this step.
+
+        """
         self.steps[step.name] = step
         self.dag.add_node(step.name)
+
+        if add_dependencies:
+            for dep in step.requires:
+                self.connect(step.name, dep)
+
+        if add_dependants:
+            for parent in step.required_by:
+                self.connect(parent, step.name)
+
+    def add_step_if_not_exists(self, step, add_dependencies=False,
+                               add_dependants=False):
+        """Try to add a step to the graph.
+
+        Can be used when failure to add is acceptable.
+
+        Args:
+            step (:class:`Step`): The step to be added.
+            add_dependencies (bool): Connect steps that need to be completed
+                before this step.
+            add_dependants (bool): Connect steps that require this step.
+
+        """
+        if self.steps.get(step.name):
+            return
+
+        self.steps[step.name] = step
+        self.dag.add_node_if_not_exists(step.name)
+
+        if add_dependencies:
+            for dep in step.requires:
+                try:
+                    self.connect(step.name, dep)
+                except GraphError:
+                    continue
+
+        if add_dependants:
+            for parent in step.required_by:
+                try:
+                    self.connect(parent, step.name)
+                except GraphError:
+                    continue
+
+    def add_steps(self, steps):
+        """Add a list of steps.
+
+        Args:
+            steps (List[:class:`Step`]): The step to be added.
+
+        """
+        for step in steps:
+            self.add_step(step)
+
+        for step in steps:
+            for dep in step.requires:
+                self.connect(step.name, dep)
+
+            for parent in step.required_by:
+                self.connect(parent, step.name)
+
+    def pop(self, step, default=None):
+        """Remove a step from the graph.
+
+        Args:
+            step: (:class:`Step`): The step to remove from the graph.
+            default (Any): Returned if the step could not be popped
+
+        Returns:
+            (Any)
+
+        """
+        self.dag.delete_node_if_exists(step.name)
+        return self.steps.pop(step.name, default)
 
     def connect(self, step, dep):
         try:
@@ -290,28 +420,105 @@ class Graph(object):
     def to_dict(self):
         return self.dag.graph
 
+    def dumps(self, indent=None):
+        """Output the graph as a json seralized string for storage.
+
+        Args:
+            indent (Optional[int]): Number of spaces for each indentation.
+
+        Returns:
+            (str)
+
+        """
+        return json.dumps(self.to_dict(), default=json_serial, indent=indent)
+
+    @classmethod
+    def from_dict(cls, graph_dict, context):
+        """Create a Graph from a graph dict.
+
+        Args:
+            graph_dict (Dict[str, List[str]]): The dictionary used to
+                create the graph.
+            context (:class:`stacker.context.Context`): Required to init
+                stacks.
+
+        Returns:
+            (:class:`Graph`)
+
+        """
+        return cls.from_steps(Step.from_persistent_graph(graph_dict, context))
+
+    @classmethod
+    def from_steps(cls, steps):
+        """Create a Graph from Steps.
+
+        Args:
+            steps (List[:class:`Step`]): Steps used to create the graph.
+
+        Returns:
+            (:class:`Graph`)
+
+        """
+        graph = cls()
+        graph.add_steps(steps)
+        return graph
+
 
 class Plan(object):
     """A convenience class for working on a Graph.
+
     Args:
         description (str): description of the plan.
         graph (:class:`Graph`): a graph of steps.
+
     """
 
-    def __init__(self, description, graph):
-        self.id = uuid.uuid4()
+    def __str__(self):
+        return self.graph.dumps()
+
+    def __init__(self, context, description, graph, reverse=False,
+                 require_unlocked=True):
+        """Initialize class.
+
+        Args:
+            context (:class:`stacker.context.Context`): Context object.
+            description (str): Description of what the plan is going to do.
+            graph (:class:`Graph`): Local graph used for the plan.
+            reverse (bool): Transpose the graph for walking in reverse.
+            require_unlocked (bool): Require the persistent graph to be
+                unlocked before executing steps.
+
+        """
+        self.context = context
         self.description = description
-        self.graph = graph
+        self.id = uuid.uuid4()
+        self.locked = context.persistent_graph_locked
+        self.reverse = reverse
+        self.require_unlocked = require_unlocked
+
+        if self.reverse:
+            graph = graph.transposed()
+
+        if self.context.stack_names:
+            nodes = []
+            for target in self.context.stack_names:
+                if graph.steps.get(target):
+                    nodes.append(target)
+            self.graph = graph.filtered(nodes)
+        else:
+            self.graph = graph
 
     def outline(self, level=logging.INFO, message=""):
         """Print an outline of the actions the plan is going to take.
         The outline will represent the rough ordering of the steps that will be
         taken.
+
         Args:
             level (int, optional): a valid log level that should be used to log
                 the outline
             message (str, optional): a message that will be logged to
                 the user after the outline has been logged.
+
         """
         steps = 1
         logger.log(level, "Plan \"%s\":", self.description)
@@ -360,8 +567,14 @@ class Plan(object):
         any of the steps fail.
 
         Raises:
+            PersistentGraphLocked: Raised if the persistent graph is
+                locked prior to execution and this session did not lock it.
             PlanFailed: Raised if any of the steps fail.
+
         """
+        if self.locked and self.require_unlocked:
+            raise PersistentGraphLocked
+
         self.walk(*args, **kwargs)
 
         failed_steps = [step for step in self.steps if step.status == FAILED]
@@ -377,6 +590,17 @@ class Plan(object):
         """
 
         def walk_func(step):
+            """Execute a :class:`Step` wile walking the graph.
+
+            Handles updating the persistent graph if one is being used.
+
+            Args:
+                step (:class:`Step`): :class:`Step` to execute.
+
+            Returns:
+                (bool)
+
+            """
             # Before we execute the step, we need to ensure that it's
             # transitive dependencies are all in an "ok" state. If not, we
             # won't execute this step.
@@ -385,9 +609,40 @@ class Plan(object):
                     step.set_status(FailedStatus("dependency has failed"))
                     return step.ok
 
-            return step.run()
+            result = step.run()
+
+            if not self.context.persistent_graph:
+                return result
+
+            if (step.completed or
+                    (step.skipped and
+                     step.status.reason == ('does not exist in '
+                                            'cloudformation'))):
+                if step.fn.__name__ == '_destroy_stack':
+                    self.context.persistent_graph.pop(step)
+                    logger.debug("Removed step '%s' from the persistent graph",
+                                 step.name)
+                elif step.fn.__name__ == '_launch_stack':
+                    self.context.persistent_graph.add_step_if_not_exists(
+                        step, add_dependencies=True, add_dependants=True
+                    )
+                    logger.debug("Added step '%s' to the persistent graph",
+                                 step.name)
+                else:
+                    return result
+                self.context.put_persistent_graph(self.lock_code)
 
         return self.graph.walk(walker, walk_func)
+
+    @property
+    def lock_code(self):
+        """Used for locking/unlocking the persistent graph.
+
+        Returns:
+            (str)
+
+        """
+        return str(self.id)
 
     @property
     def steps(self):

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -705,6 +705,10 @@ class Provider(BaseProvider):
         fqn = self.get_stack_name(stack)
         logger.debug("Attempting to delete stack %s", fqn)
 
+        if action == 'build':
+            logger.info('%s was removed from the Stacker config file '
+                        'so it is being destroyed.', fqn)
+
         destroy_method = self.select_destroy_method(force_interactive)
         return destroy_method(fqn=fqn, action=action,
                               approval=approval, **kwargs)
@@ -847,7 +851,7 @@ class Provider(BaseProvider):
             ask_for_approval(include_verbose=False)
 
         logger.warn('Destroying stack \"%s\" for re-creation', stack_name)
-        self.destroy_stack(stack)
+        self.destroy_stack(stack, approval='y')
 
         return False
 
@@ -920,9 +924,6 @@ class Provider(BaseProvider):
 
         approval_options = ['y', 'n']
         try:
-            if action == 'build':
-                logger.warning('WARNING: %s was removed from the '
-                               'Stacker config file.', fqn)
             ui.lock()
             approval = approval or ui.ask("Destroy stack '{}'? [{}] ".format(
                 fqn, '/'.join(approval_options)

--- a/stacker/tests/actions/test_base.py
+++ b/stacker/tests/actions/test_base.py
@@ -6,15 +6,13 @@ standard_library.install_aliases()
 
 import unittest
 
-import mock
-
-import botocore.exceptions
-from botocore.stub import Stubber, ANY
+from mock import MagicMock, PropertyMock, patch
 
 from stacker.actions.base import (
     BaseAction
 )
 from stacker.blueprints.base import Blueprint
+from stacker.plan import Graph, Step, Plan
 from stacker.providers.aws.default import Provider
 from stacker.session_cache import get_session
 
@@ -37,92 +35,171 @@ class TestBlueprint(Blueprint):
 
 
 class TestBaseAction(unittest.TestCase):
-    def test_ensure_cfn_bucket_exists(self):
-        session = get_session("us-east-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider)
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_response(
-            "head_bucket",
-            service_response={},
-            expected_params={
-                "Bucket": ANY,
-            }
-        )
-        with stubber:
-            action.ensure_cfn_bucket()
 
-    def test_ensure_cfn_bucket_doesnt_exist_us_east(self):
-        session = get_session("us-east-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider)
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_client_error(
-            "head_bucket",
-            service_error_code="NoSuchBucket",
-            service_message="Not Found",
-            http_status_code=404,
-        )
-        stubber.add_response(
-            "create_bucket",
-            service_response={},
-            expected_params={
-                "Bucket": ANY,
-            }
-        )
-        with stubber:
-            action.ensure_cfn_bucket()
+    def setUp(self):
+        self.region = 'us-east-1'
+        self.session = get_session(self.region)
+        self.provider = Provider(self.session)
 
-    def test_ensure_cfn_bucket_doesnt_exist_us_west(self):
-        session = get_session("us-west-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider, region="us-west-1")
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_client_error(
-            "head_bucket",
-            service_error_code="NoSuchBucket",
-            service_message="Not Found",
-            http_status_code=404,
-        )
-        stubber.add_response(
-            "create_bucket",
-            service_response={},
-            expected_params={
-                "Bucket": ANY,
-                "CreateBucketConfiguration": {
-                    "LocationConstraint": "us-west-1",
-                }
-            }
-        )
-        with stubber:
-            action.ensure_cfn_bucket()
+        self.config_no_persist = {
+            'stacks': [
+                {'name': 'stack1'},
+                {'name': 'stack2',
+                 'requires': ['stack1']}
+            ]
+        }
 
-    def test_ensure_cfn_forbidden(self):
-        session = get_session("us-west-1")
-        provider = Provider(session)
-        action = BaseAction(
-            context=mock_context("mynamespace"),
-            provider_builder=MockProviderBuilder(provider)
-        )
-        stubber = Stubber(action.s3_conn)
-        stubber.add_client_error(
-            "head_bucket",
-            service_error_code="AccessDenied",
-            service_message="Forbidden",
-            http_status_code=403,
-        )
-        with stubber:
-            with self.assertRaises(botocore.exceptions.ClientError):
-                action.ensure_cfn_bucket()
+        self.config_persist = {
+            'persistent_graph_key': 'test.json',
+            'stacks': [
+                {'name': 'stack1'},
+                {'name': 'stack2',
+                 'requires': ['stack1']}
+            ]
+        }
+
+    @patch('stacker.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('stacker.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_no_persist_exclude(self, mock_stack_action,
+                                              mock_tags):
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_no_persist,
+                               region=self.region)
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=False)
+
+        mock_tags.assert_not_called()
+        self.assertIsInstance(plan, Plan)
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('stacker.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('stacker.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_no_persist_include(self, mock_stack_action,
+                                              mock_tags):
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_no_persist,
+                               region=self.region)
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=True)
+
+        mock_tags.assert_not_called()
+        self.assertIsInstance(plan, Plan)
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('stacker.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('stacker.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_with_persist_exclude(self, mock_stack_action,
+                                                mock_tags):
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_persist,
+                               region=self.region)
+        persist_step = Step.from_stack_name('removed', context)
+        context._persistent_graph = Graph.from_steps([persist_step])
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=False)
+
+        self.assertIsInstance(plan, Plan)
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('stacker.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('stacker.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_with_persist_include(self, mock_stack_action,
+                                                mock_tags):
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_persist,
+                               region=self.region)
+        persist_step = Step.from_stack_name('removed', context)
+        context._persistent_graph = Graph.from_steps([persist_step])
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=True)
+
+        self.assertIsInstance(plan, Plan)
+        mock_tags.assert_called_once()
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(3, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(set(), result_graph_dict['removed'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertTrue(plan.require_unlocked)
+
+    @patch('stacker.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    @patch('stacker.actions.base.BaseAction._stack_action',
+           new_callable=PropertyMock)
+    def test_generate_plan_with_persist_no_lock_req(self, mock_stack_action,
+                                                    mock_tags):
+        mock_stack_action.return_value = MagicMock()
+        mock_tags.return_value = {}
+        context = mock_context(namespace='test',
+                               extra_config_args=self.config_persist,
+                               region=self.region)
+        persist_step = Step.from_stack_name('removed', context)
+        context._persistent_graph = Graph.from_steps([persist_step])
+        action = BaseAction(context=context,
+                            provider_builder=MockProviderBuilder(
+                                self.provider, region=self.region))
+
+        plan = action._generate_plan(include_persistent_graph=True,
+                                     require_unlocked=False)
+
+        self.assertIsInstance(plan, Plan)
+        mock_tags.assert_called_once()
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(3, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict['stack1'])
+        self.assertEqual(set(['stack1']), result_graph_dict['stack2'])
+        self.assertEqual(set(), result_graph_dict['removed'])
+        self.assertEqual(BaseAction.DESCRIPTION, plan.description)
+        self.assertFalse(plan.require_unlocked)
 
     def test_stack_template_url(self):
         context = mock_context("mynamespace")
@@ -137,8 +214,8 @@ class TestBaseAction(unittest.TestCase):
             provider_builder=MockProviderBuilder(provider, region=region)
         )
 
-        with mock.patch('stacker.actions.base.get_s3_endpoint', autospec=True,
-                        return_value=endpoint):
+        with patch('stacker.actions.base.get_s3_endpoint', autospec=True,
+                   return_value=endpoint):
             self.assertEqual(
                 action.stack_template_url(blueprint),
                 "%s/%s/stack_templates/%s/%s-%s.json" % (

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -70,8 +70,10 @@ class FunctionalTests(Blueprint):
                         Action=[
                             awacs.s3.ListBucket,
                             awacs.s3.GetBucketLocation,
+                            awacs.s3.GetBucketVersioning,
                             awacs.s3.CreateBucket,
                             awacs.s3.DeleteBucket,
+                            awacs.s3.PutBucketVersioning
                         ]
                     ),
                     Statement(
@@ -89,6 +91,9 @@ class FunctionalTests(Blueprint):
                         Resource=[objects_arn],
                         Action=[
                             awacs.s3.DeleteObject,
+                            awacs.s3.DeleteObjectTagging,
+                            awacs.s3.GetObjectTagging,
+                            awacs.s3.PutObjectTagging
                         ]
                     ),
                     Statement(

--- a/stacker/tests/hooks/test_keypair.py
+++ b/stacker/tests/hooks/test_keypair.py
@@ -118,7 +118,7 @@ def test_import_bad_key_data(tmpdir, provider, context):
     assert result is False
 
 
-@pytest.mark.parametrize('ssm_key_id', (None, 'my-key'))
+@pytest.mark.parametrize('ssm_key_id', ('my-key'))
 def test_create_in_ssm(provider, context, ssh_key, ssm_key_id):
     result = ensure_keypair_exists(provider, context, keypair=KEY_PAIR_NAME,
                                    ssm_parameter_name='param',

--- a/stacker/tests/lookups/handlers/test_kms.py
+++ b/stacker/tests/lookups/handlers/test_kms.py
@@ -2,35 +2,51 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 import codecs
+from mock import patch
 import unittest
 
-from moto import mock_kms
-
 import boto3
+from botocore.stub import Stubber
 
 from stacker.lookups.handlers.kms import KmsLookup
+from stacker.tests.factories import SessionStub, mock_provider
+
+
+REGION = 'us-east-1'
 
 
 class TestKMSHandler(unittest.TestCase):
+    client = boto3.client('kms', region_name=REGION)
+
     def setUp(self):
-        self.plain = b"my secret"
-        with mock_kms():
-            kms = boto3.client("kms", region_name="us-east-1")
-            self.secret = kms.encrypt(
-                KeyId="alias/stacker",
-                Plaintext=codecs.encode(self.plain, 'base64').decode('utf-8'),
-            )["CiphertextBlob"]
-            if isinstance(self.secret, bytes):
-                self.secret = self.secret.decode()
+        self.stubber = Stubber(self.client)
+        self.provider = mock_provider(region=REGION)
+        self.secret = b'my secret'
 
-    def test_kms_handler(self):
-        with mock_kms():
-            decrypted = KmsLookup.handle(self.secret)
-            self.assertEqual(decrypted, self.plain)
+    @patch("stacker.lookups.handlers.kms.get_session",
+           return_value=SessionStub(client))
+    def test_kms_handler(self, _mock_client):
+        self.stubber.add_response('decrypt', {'Plaintext': self.secret},
+                                  {'CiphertextBlob': codecs.decode(self.secret,
+                                                                   'base64')})
 
-    def test_kms_handler_with_region(self):
-        region = "us-east-1"
-        value = "%s@%s" % (region, self.secret)
-        with mock_kms():
-            decrypted = KmsLookup.handle(value)
-            self.assertEqual(decrypted, self.plain)
+        with self.stubber:
+            self.assertEqual(self.secret,
+                             KmsLookup.handle(value=self.secret.decode(),
+                                              provider=self.provider))
+            self.stubber.assert_no_pending_responses()
+
+    @patch("stacker.lookups.handlers.kms.get_session",
+           return_value=SessionStub(client))
+    def test_kms_handler_with_region(self, _mock_client):
+        value = '{}@{}'.format(REGION, self.secret.decode())
+
+        self.stubber.add_response('decrypt', {'Plaintext': self.secret},
+                                  {'CiphertextBlob': codecs.decode(self.secret,
+                                                                   'base64')})
+
+        with self.stubber:
+            self.assertEqual(self.secret,
+                             KmsLookup.handle(value=value,
+                                              provider=self.provider))
+            self.stubber.assert_no_pending_responses()

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -1,11 +1,47 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+import io
+import json
 import unittest
 
+from botocore.exceptions import ClientError
+from botocore.response import StreamingBody
+from botocore.stub import Stubber, ANY
+from mock import patch, PropertyMock
+
+from stacker.exceptions import (PersistentGraphCannotLock,
+                                PersistentGraphCannotUnlock,
+                                PersistentGraphLocked,
+                                PersistentGraphLockCodeMissmatch,
+                                PersistentGraphUnlocked)
 from stacker.context import Context, get_fqn
 from stacker.config import load, Config
 from stacker.hooks.utils import handle_hooks
+from stacker.plan import Graph, json_serial
+
+
+def gen_tagset(tags):
+    """Creates TagSet value from a dict."""
+    return [{'Key': key, 'Value': value} for key, value in tags.items()]
+
+
+def gen_s3_object_content(content):
+    """Convert a string or dict to S3 object body.
+
+    Args:
+        content (Union[str, Dict[str, Any]]): S3 object body
+
+    Returns:
+        (botocore.response.StreamingBody) Used in the Body of a
+            s3.get_object response.
+
+    """
+    if isinstance(content, dict):
+        content = json.dumps(content, default=json_serial)
+    encoded_content = content.encode()
+    return StreamingBody(io.BytesIO(encoded_content),
+                         len(encoded_content))
 
 
 class TestContext(unittest.TestCase):
@@ -15,6 +51,15 @@ class TestContext(unittest.TestCase):
             "namespace": "namespace",
             "stacks": [
                 {"name": "stack1"}, {"name": "stack2"}]})
+        self.persist_graph_raw_config = {
+            'namespace': 'test',
+            'stacker_bucket': 'stacker-test',
+            'stacker_bucket_region': 'us-east-1',
+            'persistent_graph_key': 'test.json',
+            'stacks': [
+                {'name': 'stack1'}, {'name': 'stack2', 'requires': ['stack1']}]
+        }
+        self.persist_graph_config = Config(self.persist_graph_raw_config)
 
     def test_context_optional_keys_set(self):
         context = Context(
@@ -64,7 +109,7 @@ class TestContext(unittest.TestCase):
         context = Context(config=Config({"namespace": "test"}))
         self.assertEqual(context.bucket_name, "stacker-test")
 
-    def test_context_bucket_name_is_overriden_but_is_none(self):
+    def test_context_bucket_name_is_overridden_but_is_none(self):
         config = Config({"namespace": "test", "stacker_bucket": ""})
         context = Context(config=config)
         self.assertEqual(context.bucket_name, None)
@@ -73,7 +118,7 @@ class TestContext(unittest.TestCase):
         context = Context(config=config)
         self.assertEqual(context.bucket_name, "stacker-test")
 
-    def test_context_bucket_name_is_overriden(self):
+    def test_context_bucket_name_is_overridden(self):
         config = Config({"namespace": "test", "stacker_bucket": "bucket123"})
         context = Context(config=config)
         self.assertEqual(context.bucket_name, "bucket123")
@@ -89,13 +134,13 @@ class TestContext(unittest.TestCase):
             config=Config({"namespace": None, "stacker_bucket": ""}))
         self.assertEqual(context.bucket_name, None)
 
-    def test_context_namespace_delimiter_is_overriden_and_not_none(self):
+    def test_context_namespace_delimiter_is_overridden_and_not_none(self):
         config = Config({"namespace": "namespace", "namespace_delimiter": "_"})
         context = Context(config=config)
         fqn = context.get_fqn("stack1")
         self.assertEqual(fqn, "namespace_stack1")
 
-    def test_context_namespace_delimiter_is_overriden_and_is_empty(self):
+    def test_context_namespace_delimiter_is_overridden_and_is_empty(self):
         config = Config({"namespace": "namespace", "namespace_delimiter": ""})
         context = Context(config=config)
         fqn = context.get_fqn("stack1")
@@ -127,6 +172,489 @@ class TestContext(unittest.TestCase):
         stage = "pre_build"
         handle_hooks(stage, context.config[stage], "mock-region-1", context)
         self.assertEqual("mockResult", context.hook_data["myHook"]["result"])
+
+    def test_persistent_graph_location(self):
+        context = Context(config=self.persist_graph_config)
+        expected = {
+            'Bucket': 'stacker-test',
+            'Key': 'persistent_graphs/test/test.json'
+        }
+        self.assertEqual(expected, context.persistent_graph_location)
+
+    def test_persistent_graph_location_no_json(self):
+        """'.json' appended to the key if it does not exist."""
+        cp_config = self.persist_graph_raw_config.copy()
+        cp_config['persistent_graph_key'] = 'test'
+
+        context = Context(config=Config(cp_config))
+        expected = {
+            'Bucket': 'stacker-test',
+            'Key': 'persistent_graphs/test/test.json'
+        }
+        self.assertEqual(expected, context.persistent_graph_location)
+
+    def test_persistent_graph_location_no_key(self):
+        """Return an empty dict if key is not set."""
+        context = Context(config=self.config)
+        self.assertEqual({}, context.persistent_graph_location)
+
+    def test_persistent_graph_location_no_bucket(self):
+        """Return an empty dict if key is set but no bucket name."""
+        cp_config = self.persist_graph_raw_config.copy()
+        cp_config['stacker_bucket'] = ''
+
+        context = Context(config=Config(cp_config))
+        self.assertEqual({}, context.persistent_graph_location)
+
+    @patch('stacker.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    def test_persistent_graph_lock_code_disabled(self, mock_prop):
+        """Return 'None' when not used."""
+        mock_prop.return_value = None
+        context = Context(config=Config(self.config))
+        mock_prop.assert_not_called()
+        self.assertIsNone(context.persistent_graph_lock_code)
+
+    def test_persistent_graph_lock_code_present(self):
+        """Return the value of the lock tag when it exists."""
+        context = Context(config=self.persist_graph_config)
+        stubber = Stubber(context.s3_conn)
+        code = '0000'
+
+        stubber.add_response('get_object_tagging', {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }, context.persistent_graph_location)
+
+        with stubber:
+            self.assertIsNone(context._persistent_graph_lock_code)
+            self.assertEqual(code, context.persistent_graph_lock_code)
+            self.assertEqual(code, context._persistent_graph_lock_code)
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_lock_code_none(self):
+        """Return 'None' when the tag is not set."""
+        context = Context(config=self.persist_graph_config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging', {'TagSet': []},
+                             context.persistent_graph_location)
+
+        with stubber:
+            self.assertIsNone(context.persistent_graph_lock_code)
+            self.assertIsNone(context._persistent_graph_lock_code)
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_lock_code_no_object(self):
+        """Return 'None' when object does not exist."""
+        context = Context(config=self.persist_graph_config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            'get_object_tagging', 'NoSuchKey',
+            expected_params=context.persistent_graph_location)
+
+        with stubber:
+            self.assertIsNone(context.persistent_graph_lock_code)
+            self.assertIsNone(context._persistent_graph_lock_code)
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph(self):
+        """Return Graph from S3 object."""
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'ResponseContentType': 'application/json'}
+        expected_params.update(context.persistent_graph_location)
+        expected_content = {
+            'stack1': set(),
+            'stack2': set(['stack1'])
+        }
+
+        stubber.add_response('get_object',
+                             {'Body': gen_s3_object_content(expected_content)},
+                             expected_params)
+
+        with stubber:
+            self.assertIsNone(context._persistent_graph)
+            self.assertIsInstance(context.persistent_graph, Graph)
+            self.assertIsInstance(context._persistent_graph, Graph)
+            self.assertEqual(expected_content,
+                             context.persistent_graph.to_dict())
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_no_object(self):
+        """Create object if one does not exist and return empty Graph."""
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        stubber = Stubber(context.s3_conn)
+        expected_get_params = {'ResponseContentType': 'application/json'}
+        expected_get_params.update(context.persistent_graph_location)
+        expected_put_params = {'Body': '{}',
+                               'ServerSideEncryption': 'AES256',
+                               'ACL': 'bucket-owner-full-control',
+                               'ContentType': 'application/json'}
+        expected_put_params.update(context.persistent_graph_location)
+
+        stubber.add_client_error('get_object', 'NoSuchKey',
+                                 expected_params=expected_get_params)
+        stubber.add_response('put_object', {}, expected_put_params)
+
+        with stubber:
+            self.assertIsNone(context._persistent_graph)
+            self.assertIsInstance(context.persistent_graph, Graph)
+            self.assertIsInstance(context._persistent_graph, Graph)
+            self.assertEqual({}, context.persistent_graph.to_dict())
+            stubber.assert_no_pending_responses()
+
+    def test_persistent_graph_disabled(self):
+        """Return 'None' when key is not set."""
+        context = Context(config=self.config)
+        self.assertIsNone(context._persistent_graph)
+        self.assertIsNone(context.persistent_graph)
+
+    def test_lock_persistent_graph(self):
+        """Return 'None' when lock is successful."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Tagging': {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_response('get_object_tagging', {'TagSet': []},
+                             context.persistent_graph_location)
+        stubber.add_response('put_object_tagging', {}, expected_params)
+
+        with stubber:
+            self.assertIsNone(context.lock_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    def test_lock_persistent_graph_locked(self):
+        """Error raised when when object is locked."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Tagging': {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: '1111'}
+                             )},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphLocked):
+                context.lock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_lock_persistent_graph_no_object(self):
+        """Error raised when when there is no object to lock."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Tagging': {
+            'TagSet': gen_tagset({context._persistent_graph_lock_tag: code})
+        }}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_client_error(
+            'get_object_tagging', 'NoSuchKey',
+            expected_params=context.persistent_graph_location
+        )
+        stubber.add_client_error('put_object_tagging', 'NoSuchKey',
+                                 expected_params=expected_params)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphCannotLock):
+                context.lock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph(self):
+        """Return 'None' when put is successful."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        graph_dict = {
+            'stack1': [],
+            'stack2': ['stack1']
+        }
+        context._persistent_graph = Graph.from_dict(graph_dict, context)
+        stubber = Stubber(context.s3_conn)
+        expected_params = {'Body': json.dumps(graph_dict, indent=4),
+                           'ServerSideEncryption': 'AES256',
+                           'ACL': 'bucket-owner-full-control',
+                           'ContentType': 'application/json',
+                           'Tagging': '{}={}'.format(
+                               context._persistent_graph_lock_tag,
+                               code)}
+        expected_params.update(context.persistent_graph_location)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: code}
+                             )},
+                             context.persistent_graph_location)
+        stubber.add_response('put_object', {}, expected_params)
+
+        with stubber:
+            self.assertIsNone(context.put_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph_unlocked(self):
+        """Error raised when trying to update an unlocked object"""
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging', {'TagSet': []},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphUnlocked):
+                context.put_persistent_graph('')
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph_code_missmatch(self):
+        """Error raised when provided lock code does not match object."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: '1111'}
+                             )},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphLockCodeMissmatch):
+                context.put_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_put_persistent_graph_empty(self):
+        """Object deleted when persistent graph is empty."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: code}
+                             )},
+                             context.persistent_graph_location)
+        stubber.add_response('delete_object', {},
+                             context.persistent_graph_location)
+
+        with stubber:
+            self.assertFalse(context.persistent_graph.to_dict())
+            self.assertIsNone(context.put_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    @patch('stacker.context.Context._persistent_graph_tags',
+           new_callable=PropertyMock)
+    def test_persistent_graph_locked(self, mock_prop):
+        """Return 'True' or 'False' based on code property."""
+        mock_prop.return_value = {}
+        context = Context(config=self.persist_graph_config)
+        context._persistent_graph = True
+
+        context._persistent_graph_lock_code = True
+        self.assertTrue(context.persistent_graph_locked)
+
+        context._persistent_graph_lock_code = None
+        self.assertFalse(context.persistent_graph_locked)
+        mock_prop.assert_called_once()
+
+    def test_persistent_graph_locked_disabled(self):
+        """Return 'None' when key is not set."""
+        context = Context(config=self.config)
+        self.assertFalse(context.persistent_graph_locked)
+
+    def test_s3_bucket_exists(self):
+        context = Context(config=self.config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response(
+            "head_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+            }
+        )
+
+        with stubber:
+            self.assertIsNone(context._s3_bucket_verified)
+            self.assertTrue(context.s3_bucket_verified)
+            self.assertTrue(context._s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_s3_bucket_doesnt_exist_us_east(self):
+        """Create S3 bucket when it does not exist."""
+        context = Context(config=self.config, region='us-east-1')
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="NoSuchBucket",
+            service_message="Not Found",
+            http_status_code=404,
+        )
+        stubber.add_response(
+            "create_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+            }
+        )
+
+        with stubber:
+            self.assertIsNone(context._s3_bucket_verified)
+            self.assertTrue(context.s3_bucket_verified)
+            self.assertTrue(context._s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_s3_bucket_doesnt_exist_us_west(self):
+        """Create S3 bucket with loc constraints when it does not exist."""
+        region = 'us-west-1'
+        context = Context(config=self.config, region=region)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="NoSuchBucket",
+            service_message="Not Found",
+            http_status_code=404,
+        )
+        stubber.add_response(
+            "create_bucket",
+            service_response={},
+            expected_params={
+                "Bucket": ANY,
+                "CreateBucketConfiguration": {
+                    "LocationConstraint": region,
+                }
+            }
+        )
+
+        with stubber:
+            self.assertIsNone(context._s3_bucket_verified)
+            self.assertTrue(context.s3_bucket_verified)
+            self.assertTrue(context._s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_s3_bucket_forbidden(self):
+        """Error raised when S3 bucket exists but cannot access."""
+        context = Context(config=self.config)
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="AccessDenied",
+            service_message="Forbidden",
+            http_status_code=403,
+        )
+
+        with stubber:
+            with self.assertRaises(ClientError):
+                self.assertFalse(context.s3_bucket_verified)
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph(self):
+        """Return 'True' when delete tag is successful."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: code}
+                             )},
+                             context.persistent_graph_location)
+        stubber.add_response('delete_object_tagging', {},
+                             context.persistent_graph_location)
+
+        with stubber:
+            self.assertTrue(context.unlock_persistent_graph(code))
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph_not_locked(self):
+        """Error raised when object is not locked."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': []},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphCannotUnlock):
+                context.unlock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph_code_missmatch(self):
+        """Error raised when local code does not match object."""
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: '1111'}
+                             )},
+                             context.persistent_graph_location)
+
+        with stubber:
+            with self.assertRaises(PersistentGraphCannotUnlock):
+                context.unlock_persistent_graph(code)
+            stubber.assert_no_pending_responses()
+
+    def test_unlock_persistent_graph_no_object(self):
+        """Return 'None' when object does not exist.
+
+        This can occur if the object is deleted by 'put_persistent_graph'.
+
+        """
+        code = '0000'
+        context = Context(config=self.persist_graph_config)
+        context._s3_bucket_verified = True
+        context._persistent_graph = Graph()
+        stubber = Stubber(context.s3_conn)
+
+        stubber.add_response('get_object_tagging',
+                             {'TagSet': gen_tagset(
+                                 {context._persistent_graph_lock_tag: code}
+                             )},
+                             context.persistent_graph_location)
+        stubber.add_client_error(
+            'delete_object_tagging', 'NoSuchKey',
+            expected_params=context.persistent_graph_location
+        )
+
+        with stubber:
+            self.assertTrue(context.unlock_persistent_graph(code))
+            stubber.assert_no_pending_responses()
 
 
 class TestFunctions(unittest.TestCase):

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -414,7 +414,7 @@ class TestContext(unittest.TestCase):
         """Error raised when trying to update an unlocked object"""
         context = Context(config=self.persist_graph_config)
         context._s3_bucket_verified = True
-        context._persistent_graph = Graph()
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
         stubber = Stubber(context.s3_conn)
 
         stubber.add_response('get_object_tagging', {'TagSet': []},
@@ -430,7 +430,7 @@ class TestContext(unittest.TestCase):
         code = '0000'
         context = Context(config=self.persist_graph_config)
         context._s3_bucket_verified = True
-        context._persistent_graph = Graph()
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
         stubber = Stubber(context.s3_conn)
 
         stubber.add_response('get_object_tagging',
@@ -452,11 +452,6 @@ class TestContext(unittest.TestCase):
         context._persistent_graph = Graph()
         stubber = Stubber(context.s3_conn)
 
-        stubber.add_response('get_object_tagging',
-                             {'TagSet': gen_tagset(
-                                 {context._persistent_graph_lock_tag: code}
-                             )},
-                             context.persistent_graph_location)
         stubber.add_response('delete_object', {},
                              context.persistent_graph_location)
 
@@ -579,7 +574,7 @@ class TestContext(unittest.TestCase):
         code = '0000'
         context = Context(config=self.persist_graph_config)
         context._s3_bucket_verified = True
-        context._persistent_graph = Graph()
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
         stubber = Stubber(context.s3_conn)
 
         stubber.add_response('get_object_tagging',
@@ -599,7 +594,7 @@ class TestContext(unittest.TestCase):
         code = '0000'
         context = Context(config=self.persist_graph_config)
         context._s3_bucket_verified = True
-        context._persistent_graph = Graph()
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
         stubber = Stubber(context.s3_conn)
 
         stubber.add_response('get_object_tagging',
@@ -616,7 +611,7 @@ class TestContext(unittest.TestCase):
         code = '0000'
         context = Context(config=self.persist_graph_config)
         context._s3_bucket_verified = True
-        context._persistent_graph = Graph()
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
         stubber = Stubber(context.s3_conn)
 
         stubber.add_response('get_object_tagging',
@@ -641,19 +636,16 @@ class TestContext(unittest.TestCase):
         context._s3_bucket_verified = True
         context._persistent_graph = Graph()
         stubber = Stubber(context.s3_conn)
+        expected_params = context.persistent_graph_location.copy()
+        expected_params.update({'ResponseContentType': 'application/json'})
 
-        stubber.add_response('get_object_tagging',
-                             {'TagSet': gen_tagset(
-                                 {context._persistent_graph_lock_tag: code}
-                             )},
-                             context.persistent_graph_location)
         stubber.add_client_error(
-            'delete_object_tagging', 'NoSuchKey',
-            expected_params=context.persistent_graph_location
+            'get_object', 'NoSuchKey',
+            expected_params=expected_params
         )
 
         with stubber:
-            self.assertTrue(context.unlock_persistent_graph(code))
+            self.assertIsNone(context.unlock_persistent_graph(code))
             stubber.assert_no_pending_responses()
 
 

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from builtins import range
+import json
 import os
 import shutil
 import tempfile
@@ -17,14 +18,15 @@ from stacker.lookups.registry import (
     unregister_lookup_handler,
 )
 from stacker.plan import (
-    Step,
-    build_plan,
-    build_graph,
+    Graph,
+    Plan,
+    Step
 )
 from stacker.exceptions import (
     CancelExecution,
     GraphError,
-    PlanFailed,
+    PersistentGraphLocked,
+    PlanFailed
 )
 from stacker.status import (
     SUBMITTED,
@@ -34,7 +36,7 @@ from stacker.status import (
 )
 from stacker.stack import Stack
 
-from .factories import generate_definition
+from .factories import generate_definition, mock_context
 
 count = 0
 
@@ -66,6 +68,87 @@ class TestStep(unittest.TestCase):
         self.assertNotEqual(self.step.status, False)
         self.assertNotEqual(self.step.status, 'banana')
 
+    def test_from_stack_name(self):
+        """Return step from step name."""
+        context = mock_context()
+        stack_name = 'test-stack'
+        result = Step.from_stack_name(stack_name, context)
+
+        self.assertIsInstance(result, Step)
+        self.assertEqual(stack_name, result.stack.name)
+
+    def test_from_persistent_graph(self):
+        """Return list of steps from graph dict."""
+        context = mock_context()
+        graph_dict = {
+            'stack1': [],
+            'stack2': ['stack1']
+        }
+        result = Step.from_persistent_graph(graph_dict, context)
+
+        self.assertEqual(2, len(result))
+        self.assertIsInstance(result, list)
+
+        for step in result:
+            self.assertIsInstance(step, Step)
+            self.assertIn(step.stack.name, graph_dict.keys())
+
+
+class TestGraph(unittest.TestCase):
+
+    def setUp(self):
+        self.context = mock_context()
+        self.graph_dict = {
+            'stack1': [],
+            'stack2': ['stack1']
+        }
+        self.graph_dict_expected = {
+            'stack1': set(),
+            'stack2': set(['stack1'])
+        }
+        self.steps = Step.from_persistent_graph(self.graph_dict,
+                                                self.context)
+
+    def test_add_steps(self):
+        graph = Graph()
+        graph.add_steps(self.steps)
+
+        self.assertEqual(self.steps, list(graph.steps.values()))
+        self.assertEqual([step.name for step in self.steps],
+                         list(graph.steps.keys()))
+        self.assertEqual(self.graph_dict_expected, graph.to_dict())
+
+    def test_pop(self):
+        graph = Graph()
+        graph.add_steps(self.steps)
+
+        stack2 = next(step for step in self.steps if step.name == 'stack2')
+
+        self.assertEqual(stack2, graph.pop(stack2))
+        self.assertEqual({'stack1': set()}, graph.to_dict())
+
+    def test_dumps(self):
+        graph = Graph()
+        graph.add_steps(self.steps)
+
+        self.assertEqual(json.dumps(self.graph_dict), graph.dumps())
+
+    def test_from_dict(self):
+        graph = Graph.from_dict(self.graph_dict, self.context)
+
+        self.assertIsInstance(graph, Graph)
+        self.assertEqual([step.name for step in self.steps],
+                         list(graph.steps.keys()))
+        self.assertEqual(self.graph_dict_expected, graph.to_dict())
+
+    def test_from_steps(self):
+        graph = Graph.from_steps(self.steps)
+
+        self.assertEqual(self.steps, list(graph.steps.values()))
+        self.assertEqual([step.name for step in self.steps],
+                         list(graph.steps.keys()))
+        self.assertEqual(self.graph_dict_expected, graph.to_dict())
+
 
 class TestPlan(unittest.TestCase):
 
@@ -86,34 +169,113 @@ class TestPlan(unittest.TestCase):
             definition=generate_definition('bastion', 1, requires=[vpc.name]),
             context=self.context)
 
-        graph = build_graph([
+        graph = Graph.from_steps([
             Step(vpc, fn=None), Step(bastion, fn=None)])
-        plan = build_plan(description="Test", graph=graph)
+        plan = Plan(description="Test", graph=graph)
 
         self.assertEqual(plan.graph.to_dict(), {
             'bastion.1': set(['vpc.1']),
             'vpc.1': set([])})
 
-    def test_execute_plan(self):
+    def test_plan_reverse(self):
         vpc = Stack(
             definition=generate_definition('vpc', 1),
             context=self.context)
         bastion = Stack(
             definition=generate_definition('bastion', 1, requires=[vpc.name]),
             context=self.context)
+        graph = Graph.from_steps([
+            Step(vpc, fn=None), Step(bastion, fn=None)])
+        plan = Plan(description="Test", graph=graph, reverse=True)
+
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = plan.graph.to_dict()
+        self.assertEqual(set(), result_graph_dict.get('bastion.1'))
+        self.assertEqual(set(['bastion.1']), result_graph_dict.get('vpc.1'))
+
+    def test_plan_targeted(self):
+        context = Context(config=self.config)
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.name]),
+            context=context)
+        context.stack_names = [vpc.name]
+        graph = Graph.from_steps([
+            Step(vpc, fn=None), Step(bastion, fn=None)])
+        plan = Plan(description="Test", graph=graph, context=context)
+
+        self.assertEqual({vpc.name: set()}, plan.graph.to_dict())
+
+    def test_execute_plan(self):
+        context = Context(config=self.config)
+        context.put_persistent_graph = mock.MagicMock()
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.name]),
+            context=context)
+        removed = Stack(
+            definition=generate_definition('removed', 1, requires=[]),
+            context=context)
+        context._persistent_graph = Graph.from_steps([removed])
 
         calls = []
 
-        def fn(stack, status=None):
+        def _launch_stack(stack, status=None):
             calls.append(stack.fqn)
             return COMPLETE
 
-        graph = build_graph([Step(vpc, fn), Step(bastion, fn)])
-        plan = build_plan(
-            description="Test", graph=graph)
+        def _destroy_stack(stack, status=None):
+            calls.append(stack.fqn)
+            return COMPLETE
+
+        graph = Graph.from_steps([Step(removed, _destroy_stack),
+                                  Step(vpc, _launch_stack),
+                                  Step(bastion, _launch_stack)])
+        plan = Plan(description="Test", graph=graph, context=context)
+        plan.context._persistent_graph_lock_code = plan.lock_code
         plan.execute(walk)
 
-        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+        # the order these are appended changes between python2/3
+        self.assertIn('namespace-vpc.1', calls)
+        self.assertIn('namespace-bastion.1', calls)
+        self.assertIn('namespace-removed.1', calls)
+        context.put_persistent_graph.assert_called()
+
+        # order is different between python2/3 so can't compare dicts
+        result_graph_dict = context.persistent_graph.to_dict()
+        self.assertEqual(2, len(result_graph_dict))
+        self.assertEqual(set(), result_graph_dict.get('vpc.1'))
+        self.assertEqual(set(['vpc.1']), result_graph_dict.get('bastion.1'))
+        self.assertIsNone(result_graph_dict.get('namespace-removed.1'))
+
+    def test_execute_plan_no_persist(self):
+        context = Context(config=self.config)
+        context.put_persistent_graph = mock.MagicMock()
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.name]),
+            context=context)
+
+        calls = []
+
+        def _launch_stack(stack, status=None):
+            calls.append(stack.fqn)
+            return COMPLETE
+
+        graph = Graph.from_steps([Step(vpc, _launch_stack),
+                                  Step(bastion, _launch_stack)])
+        plan = Plan(description="Test", graph=graph, context=context)
+
+        plan.execute(walk)
+
+        self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+        context.put_persistent_graph.assert_not_called()
 
     def test_execute_plan_filtered(self):
         vpc = Stack(
@@ -132,12 +294,15 @@ class TestPlan(unittest.TestCase):
             calls.append(stack.fqn)
             return COMPLETE
 
-        graph = build_graph([
+        context = mock.MagicMock()
+        context.persistent_graph_locked = False
+        context.stack_names = ['db.1']
+        graph = Graph.from_steps([
             Step(vpc, fn), Step(db, fn), Step(app, fn)])
-        plan = build_plan(
+        plan = Plan(
+            context=context,
             description="Test",
-            graph=graph,
-            targets=['db.1'])
+            graph=graph)
         plan.execute(walk)
 
         self.assertEquals(calls, [
@@ -162,8 +327,8 @@ class TestPlan(unittest.TestCase):
         vpc_step = Step(vpc, fn)
         bastion_step = Step(bastion, fn)
 
-        graph = build_graph([vpc_step, bastion_step])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([vpc_step, bastion_step])
+        plan = Plan(description="Test", graph=graph)
 
         with self.assertRaises(PlanFailed):
             plan.execute(walk)
@@ -190,8 +355,8 @@ class TestPlan(unittest.TestCase):
         vpc_step = Step(vpc, fn)
         bastion_step = Step(bastion, fn)
 
-        graph = build_graph([vpc_step, bastion_step])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([vpc_step, bastion_step])
+        plan = Plan(description="Test", graph=graph)
         plan.execute(walk)
 
         self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
@@ -219,9 +384,9 @@ class TestPlan(unittest.TestCase):
         bastion_step = Step(bastion, fn)
         db_step = Step(db, fn)
 
-        graph = build_graph([
+        graph = Graph.from_steps([
             vpc_step, bastion_step, db_step])
-        plan = build_plan(description="Test", graph=graph)
+        plan = Plan(description="Test", graph=graph)
         with self.assertRaises(PlanFailed):
             plan.execute(walk)
 
@@ -248,11 +413,21 @@ class TestPlan(unittest.TestCase):
         vpc_step = Step(vpc, fn)
         bastion_step = Step(bastion, fn)
 
-        graph = build_graph([vpc_step, bastion_step])
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps([vpc_step, bastion_step])
+        plan = Plan(description="Test", graph=graph)
         plan.execute(walk)
 
         self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+
+    def test_execute_plan_locked(self):
+        context = Context(config=self.config)
+        context._persistent_graph = Graph.from_dict({'stack1': []}, context)
+        context._persistent_graph_lock_code = '1111'
+        plan = Plan(description='Test', graph=Graph(), context=context)
+        print(plan.locked)
+
+        with self.assertRaises(PersistentGraphLocked):
+            plan.execute()
 
     def test_build_graph_missing_dependency(self):
         bastion = Stack(
@@ -261,7 +436,7 @@ class TestPlan(unittest.TestCase):
             context=self.context)
 
         with self.assertRaises(GraphError) as expected:
-            build_graph([Step(bastion, None)])
+            Graph.from_steps([Step(bastion, None)])
         message_starts = (
             "Error detected when adding 'vpc.1' "
             "as a dependency of 'bastion.1':"
@@ -285,7 +460,8 @@ class TestPlan(unittest.TestCase):
             context=self.context)
 
         with self.assertRaises(GraphError) as expected:
-            build_graph([Step(vpc, None), Step(db, None), Step(app, None)])
+            Graph.from_steps([Step(vpc, None), Step(db, None),
+                              Step(app, None)])
         message = ("Error detected when adding 'db.1' "
                    "as a dependency of 'app.1': graph is "
                    "not acyclic")
@@ -313,8 +489,8 @@ class TestPlan(unittest.TestCase):
 
             steps += [Step(stack, None)]
 
-        graph = build_graph(steps)
-        plan = build_plan(description="Test", graph=graph)
+        graph = Graph.from_steps(steps)
+        plan = Plan(description="Test", graph=graph)
 
         tmp_dir = tempfile.mkdtemp()
         try:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,8 @@
-This directory contains the functional testing suite for stacker. It exercises all of stacker against a real AWS account. Make sure you have the AWS credentials loaded into your environment when you run these steps.
+# Functional Tests
+
+This directory contains the functional testing suite for stacker. It exercises all of stacker against a real AWS account.
+
+Make sure you have the AWS credentials loaded into your environment when you run these steps. If you are using temporary credentials, be sure to save them to a credentials file as the presence of an `AWS_SESSION_TOKEN` environment variable will prevent the tests from running properly.
 
 ## Setup
 

--- a/tests/test_suite/34_stacker_build-destroy_removed_stacks.bats
+++ b/tests/test_suite/34_stacker_build-destroy_removed_stacks.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+
+@test "stacker build - destroy removed stacks" {
+  needs_aws
+
+  environment() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+EOF
+  }
+
+  initial_config() {
+    cat <<EOF
+namespace: \${namespace}
+persistent_graph_key: test.json
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    requires:
+      - vpc
+  - name: other
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+EOF
+  }
+
+  second_config() {
+    cat <<EOF
+namespace: \${namespace}
+persistent_graph_key: test.json
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    requires:
+      - vpc
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(environment) <(initial_config)
+  }
+
+  # Create the new stacks.
+  stacker build <(environment) <(initial_config)
+  assert "$status" -eq 0
+
+  for stack in vpc bastion other; do
+    assert_has_line "${stack}: submitted (creating new stack)"
+    assert_has_line "${stack}: complete (creating new stack)"
+  done
+
+  # destroy removed stack
+  stacker build <(environment) <(second_config)
+  assert "$status" -eq 0
+
+  for stack in vpc bastion; do
+    assert_has_line "${stack}: skipped (nochange)"
+  done
+
+  assert_has_line "other was removed from the Stacker config file so it is being destroyed."
+  assert_has_line "other: submitted (submitted for destruction)"
+  assert_has_line "other: complete (stack destroyed)"
+
+  # recreate "other" stack
+  stacker build <(environment) <(initial_config)
+  assert "$status" -eq 0
+
+  for stack in vpc bastion; do
+    assert_has_line "${stack}: skipped (nochange)"
+  done
+
+  assert_has_line "other: submitted (creating new stack)"
+  assert_has_line "other: complete (creating new stack)"
+
+  # destroy removed stack using persistent graph
+  stacker destroy --force <(environment) <(initial_config)
+  assert "$status" -eq 0
+
+  for stack in vpc bastion other; do
+    assert_has_line "${stack}: submitted (submitted for destruction)"
+    assert_has_line "${stack}: complete (stack destroyed)"
+  done
+}


### PR DESCRIPTION
Using a persistent graph enables a Terraform-like experience. When a stack is removed from the local config file, it will be removed from AWS. This will occur for both `build` and `destroy` actions. The `graph` and `diff` commands also take the persistent graph into account (if used).

This feature requires users **opt-in** to prevent any unexpected results in current environments. This is done by adding a the `persistent_graph_key` directive to any config file. The user is responsible for ensuring that this value is unique per stacker bucket + namespace.

The graph is persisted in the existing stacker bucket (meaning it requires use of a stacker bucket). No additional resources are required to ensure a low cost and minimally intrusive solution. It is recommended to enable versioning for the bucket to rollback any unintended changes to the object but it is not required and is not actively used by Stacker. The user is warned each use when it is not enabled and if Stacker created the bucket when the feature is opted-in, it creates the bucket with versioning enabled.

The persistent graph object is locked using tags on the S3 object (instead of a DynamoDB table like Terraform) to reduce cost and requirements. When the graph is locked, no other action that acts on the persistent graph (`build`/`destroy`) can be started.

# What Changed

- update provider destroy_stack method to have an interactive mode
- pass region option into context
- add persist graph to context
  - context method to get graph
  - context method to lock graph
  - context method to unlock graph
  - context method to put graph
- add persistent graph exceptions
- update ensure_s3_bucket
  - check for recommended bucket settings
  - applies recommended settings if creating a bucket
- update plan
  - class methods to create Step and Graph
  - remove build_graph
  - remove build_plan, all logic is now in __init__
  - add persistent graph management
  - add more methods for manipulating the graph
- update base action
  - add handling for persistent graph
  - move plan creation to a method that uses classmethods of Graph and Plan
- update graph action
  - uses parent class method to create plan
  - can include persistent graph
- update diff action
  - uses parent class method to create plan
  - can include persistent graph
- update build action
  - custom method to create plan that deletes stacks that are in the persistent graph but are no longer in the local graph
- update destroy action
  - uses parent class method to create plan
  - can include persistent graph
- add persistent_graph_key to config