### PR TITLE
KMS lookups give values $VAL wrapped as "b'$VAL'" when using python 3

### DIFF
--- a/stacker/lookups/handlers/kms.py
+++ b/stacker/lookups/handlers/kms.py
@@ -64,4 +64,4 @@ class KmsLookup(LookupHandler):
         decoded = codecs.decode(value, 'base64')
 
         # decrypt and return the plain text raw value.
-        return kms.decrypt(CiphertextBlob=decoded)["Plaintext"]
+        return kms.decrypt(CiphertextBlob=decoded)["Plaintext"].decode('utf-8')


### PR DESCRIPTION
Decrypted string is returned as b'text' which should be decoded to utf-8.