### PR TITLE
address breaking moto change to awslambda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = [
     "pytest~=4.3",
     "pytest-cov~=2.6",
     "mock~=2.0",
-    "moto~=1.3.7",
+    "moto[awslambda]~=1.3.16",
     "testfixtures~=4.10.0",
     "flake8-future-import",
 ]


### PR DESCRIPTION
Moto changed awslambda to be an extra, as of v1.3.15: https://github.com/spulec/moto/pull/3281/files

This fixes the test failures from another PR: https://github.com/cloudtools/stacker/pull/762