### PR TITLE
Fix crash when diffing a stack that has unquoted date strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Upcoming release
+- Fix crash on `stacker diff` when comparing a template with unquoted date strings
 
 ## 1.7.2 (2020-11-09)
 - address breaking moto change to awslambda [GH-763]

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -1136,7 +1136,7 @@ class Provider(BaseProvider):
         if isinstance(template, str):  # handle yaml templates
             template = parse_cloudformation_template(template)
 
-        return [json.dumps(template), parameters]
+        return [json.dumps(template, default=str), parameters]
 
     def get_stack_changes(self, stack, template, parameters,
                           tags, **kwargs):

--- a/stacker/tests/fixtures/cfn_template.yaml
+++ b/stacker/tests/fixtures/cfn_template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: 2010-09-09
 Description: TestTemplate
 Parameters:
   Param1:


### PR DESCRIPTION
Same as https://github.com/cloudtools/stacker/pull/591