### PR TITLE
Updated `set_template_description()`

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -539,7 +539,7 @@ class Blueprint(object):
                 template.
 
         """
-        self.template.add_description(description)
+        self.template.set_description(description)
 
     def add_output(self, name, value):
         """Simple helper for adding outputs.


### PR DESCRIPTION
Troposphere updated the underlying method name to be `set_description()` instead of `add_description()`. Without patching this behavior, setting a description on the top-level config file is unusable with the latest version of Troposphere, returning the following: `AttributeError: 'Template' object has no attribute 'add_description'`