### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/stacker/blueprints/testutil.py
+++ b/stacker/blueprints/testutil.py
@@ -41,7 +41,7 @@ class BlueprintTestCase(unittest.TestCase):
             expected_dict = json.loads(fd.read())
             expected_text = json.dumps(expected_dict, indent=4, sort_keys=True)
 
-        self.assertEquals(rendered_dict, expected_dict,
+        self.assertEqual(rendered_dict, expected_dict,
                           diff(rendered_text, expected_text))
 
 

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -422,5 +422,5 @@ class TestFunctions(unittest.TestCase):
         }
         params = {"a": True, "b": False}
         p = _resolve_parameters(params, self.bp)
-        self.assertEquals("true", p["a"])
-        self.assertEquals("false", p["b"])
+        self.assertEqual("true", p["a"])
+        self.assertEqual("false", p["b"])

--- a/stacker/tests/actions/test_diff.py
+++ b/stacker/tests/actions/test_diff.py
@@ -83,4 +83,4 @@ class TestDiffParameters(unittest.TestCase):
         }
 
         param_diffs = diff_parameters(old_params, new_params)
-        self.assertEquals(param_diffs, [])
+        self.assertEqual(param_diffs, [])

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -57,7 +57,7 @@ class TestBuildParameter(unittest.TestCase):
     def test_base_parameter(self):
         p = build_parameter("BasicParam", {"type": "String"})
         p.validate()
-        self.assertEquals(p.Type, "String")
+        self.assertEqual(p.Type, "String")
 
 
 class TestBlueprintRendering(unittest.TestCase):
@@ -175,7 +175,7 @@ class TestVariables(unittest.TestCase):
         blueprint = TestBlueprint(name="test", context=context,
                                   description=description)
         blueprint.render_template()
-        self.assertEquals(description, blueprint.template.description)
+        self.assertEqual(description, blueprint.template.description)
 
     def test_validate_variable_type_cfntype(self):
         var_name = "testVar"

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -522,7 +522,7 @@ class TestProviderDefaultMode(unittest.TestCase):
                   [{'force_interactive': True,
                     'force_change_set': True},
                    self.provider.interactive_update_stack]]:
-            self.assertEquals(
+            self.assertEqual(
                 self.provider.select_update_method(**i[0]),
                 i[1]
             )
@@ -955,7 +955,7 @@ class TestProviderInteractiveMode(unittest.TestCase):
                   [{'force_interactive': True,
                     'force_change_set': True},
                    self.provider.interactive_update_stack]]:
-            self.assertEquals(
+            self.assertEqual(
                 self.provider.select_update_method(**i[0]),
                 i[1]
             )

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -98,20 +98,20 @@ class TestConfig(unittest.TestCase):
         exp_dict = {'a': 1, 'b': 2, 'c': 3}
         exp_list = ['a', 'b', 'c']
 
-        self.assertEquals(pc['namespace'], 'test')
-        self.assertEquals(pc['list_var'], exp_list)
-        self.assertEquals(pc['dict_var'], exp_dict)
-        self.assertEquals(pc['str_var'], 'Hello World!')
-        self.assertEquals(pc['nested_list'][0], exp_list)
-        self.assertEquals(pc['nested_list'][1], exp_dict)
-        self.assertEquals(pc['nested_list'][2], 'another str')
-        self.assertEquals(pc['nested_dict']['a'], exp_list)
-        self.assertEquals(pc['nested_dict']['b'], exp_dict)
-        self.assertEquals(pc['nested_dict']['c'], 'another str')
-        self.assertEquals(pc['empty'], '')
-        self.assertEquals(pc['substr'], 'prefix-another str-suffix')
-        self.assertEquals(pc['multiple'], 'another str-hello')
-        self.assertEquals(pc['dont_match_this'], '${output something}')
+        self.assertEqual(pc['namespace'], 'test')
+        self.assertEqual(pc['list_var'], exp_list)
+        self.assertEqual(pc['dict_var'], exp_dict)
+        self.assertEqual(pc['str_var'], 'Hello World!')
+        self.assertEqual(pc['nested_list'][0], exp_list)
+        self.assertEqual(pc['nested_list'][1], exp_dict)
+        self.assertEqual(pc['nested_list'][2], 'another str')
+        self.assertEqual(pc['nested_dict']['a'], exp_list)
+        self.assertEqual(pc['nested_dict']['b'], exp_dict)
+        self.assertEqual(pc['nested_dict']['c'], 'another str')
+        self.assertEqual(pc['empty'], '')
+        self.assertEqual(pc['substr'], 'prefix-another str-suffix')
+        self.assertEqual(pc['multiple'], 'another str-hello')
+        self.assertEqual(pc['dont_match_this'], '${output something}')
 
     def test_render_yaml_errors(self):
         # We shouldn't be able to substitute an object into a string
@@ -141,10 +141,10 @@ class TestConfig(unittest.TestCase):
             config.validate()
 
         stack_errors = ex.exception.errors['stacks'][0]
-        self.assertEquals(
+        self.assertEqual(
             stack_errors['template_path'][0].__str__(),
             "class_path or template_path is required.")
-        self.assertEquals(
+        self.assertEqual(
             stack_errors['class_path'][0].__str__(),
             "class_path or template_path is required.")
 
@@ -169,10 +169,10 @@ class TestConfig(unittest.TestCase):
             config.validate()
 
         stack_errors = ex.exception.errors['stacks'][0]
-        self.assertEquals(
+        self.assertEqual(
             stack_errors['template_path'][0].__str__(),
             "class_path cannot be present when template_path is provided.")
-        self.assertEquals(
+        self.assertEqual(
             stack_errors['class_path'][0].__str__(),
             "template_path cannot be present when class_path is provided.")
 
@@ -186,7 +186,7 @@ class TestConfig(unittest.TestCase):
             config.validate()
 
         error = ex.exception.errors['stacks'][0]['name'].errors[0]
-        self.assertEquals(
+        self.assertEqual(
             error.__str__(),
             "This field is required.")
 
@@ -204,14 +204,14 @@ class TestConfig(unittest.TestCase):
             config.validate()
 
         error = ex.exception.errors['stacks'][0]
-        self.assertEquals(
+        self.assertEqual(
             error.__str__(),
             "Duplicate stack bastion found at index 0.")
 
     def test_dump_unicode(self):
         config = Config()
         config.namespace = "test"
-        self.assertEquals(dump(config), b"""namespace: test
+        self.assertEqual(dump(config), b"""namespace: test
 stacks: []
 """)
 
@@ -220,7 +220,7 @@ stacks: []
         # python specific objects.
         self.assertNotEquals(
             dump(config), b"namespace: !!python/unicode 'test'\n")
-        self.assertEquals(dump(config), b"""namespace: test
+        self.assertEqual(dump(config), b"""namespace: test
 stacks: []
 """)
 
@@ -232,7 +232,7 @@ stacks: []
           "hello": 1
           simple_tag: simple value
         """)
-        self.assertEquals(config.tags, {
+        self.assertEqual(config.tags, {
             "a:b": "c",
             "hello": "1",
             "simple_tag": "simple value"})
@@ -250,7 +250,7 @@ stacks: []
         """)
 
         stack = config.stacks[0]
-        self.assertEquals(stack.variables, {"Foo": "bar"})
+        self.assertEqual(stack.variables, {"Foo": "bar"})
 
     def test_parse_with_deprecated_parameters(self):
         config = parse("""
@@ -265,7 +265,7 @@ stacks: []
             config.validate()
 
         error = ex.exception.errors['stacks'][0]['parameters'][0]
-        self.assertEquals(
+        self.assertEqual(
             error.__str__(),
             "DEPRECATION: Stack definition vpc contains deprecated "
             "'parameters', rather than 'variables'. You are required to update"
@@ -275,9 +275,9 @@ stacks: []
     def test_config_build(self):
         vpc = Stack({"name": "vpc", "class_path": "blueprints.VPC"})
         config = Config({"namespace": "prod", "stacks": [vpc]})
-        self.assertEquals(config.namespace, "prod")
-        self.assertEquals(config.stacks[0].name, "vpc")
-        self.assertEquals(config["namespace"], "prod")
+        self.assertEqual(config.namespace, "prod")
+        self.assertEqual(config.stacks[0].name, "vpc")
+        self.assertEqual(config["namespace"], "prod")
         config.validate()
 
     def test_parse(self):
@@ -566,7 +566,7 @@ stacks:
         config = render_parse_load(
             conf, environment={"namespace": "prod"}, validate=False)
         config.validate()
-        self.assertEquals(config.namespace, "prod")
+        self.assertEqual(config.namespace, "prod")
 
     def test_allow_most_keys_to_be_duplicates_for_overrides(self):
         yaml_config = """

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -113,7 +113,7 @@ class TestPlan(unittest.TestCase):
             description="Test", graph=graph)
         plan.execute(walk)
 
-        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+        self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
 
     def test_execute_plan_locked(self):
         # Locked stacks still need to have their requires evaluated when
@@ -137,7 +137,7 @@ class TestPlan(unittest.TestCase):
             description="Test", graph=graph)
         plan.execute(walk)
 
-        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+        self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
 
     def test_execute_plan_filtered(self):
         vpc = Stack(
@@ -164,7 +164,7 @@ class TestPlan(unittest.TestCase):
             targets=['db.1'])
         plan.execute(walk)
 
-        self.assertEquals(calls, [
+        self.assertEqual(calls, [
             'namespace-vpc.1', 'namespace-db.1'])
 
     def test_execute_plan_exception(self):
@@ -192,8 +192,8 @@ class TestPlan(unittest.TestCase):
         with self.assertRaises(PlanFailed):
             plan.execute(walk)
 
-        self.assertEquals(calls, ['namespace-vpc.1'])
-        self.assertEquals(vpc_step.status, FAILED)
+        self.assertEqual(calls, ['namespace-vpc.1'])
+        self.assertEqual(vpc_step.status, FAILED)
 
     def test_execute_plan_skipped(self):
         vpc = Stack(
@@ -218,7 +218,7 @@ class TestPlan(unittest.TestCase):
         plan = build_plan(description="Test", graph=graph)
         plan.execute(walk)
 
-        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+        self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
 
     def test_execute_plan_failed(self):
         vpc = Stack(
@@ -251,7 +251,7 @@ class TestPlan(unittest.TestCase):
 
         calls.sort()
 
-        self.assertEquals(calls, ['namespace-db.1', 'namespace-vpc.1'])
+        self.assertEqual(calls, ['namespace-db.1', 'namespace-vpc.1'])
 
     def test_execute_plan_cancelled(self):
         vpc = Stack(
@@ -276,7 +276,7 @@ class TestPlan(unittest.TestCase):
         plan = build_plan(description="Test", graph=graph)
         plan.execute(walk)
 
-        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+        self.assertEqual(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
 
     def test_build_graph_missing_dependency(self):
         bastion = Stack(

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -85,7 +85,7 @@ class TestStack(unittest.TestCase):
             stack_id=1
         )
         stack = Stack(definition=definition, context=self.context)
-        self.assertEquals(stack.tags, {"environment": "prod"})
+        self.assertEqual(stack.tags, {"environment": "prod"})
 
     def test_stack_tags_override(self):
         self.config.tags = {"environment": "prod"}
@@ -95,7 +95,7 @@ class TestStack(unittest.TestCase):
             tags={"environment": "stage"}
         )
         stack = Stack(definition=definition, context=self.context)
-        self.assertEquals(stack.tags, {"environment": "stage"})
+        self.assertEqual(stack.tags, {"environment": "stage"})
 
     def test_stack_tags_extra(self):
         self.config.tags = {"environment": "prod"}
@@ -105,7 +105,7 @@ class TestStack(unittest.TestCase):
             tags={"app": "graph"}
         )
         stack = Stack(definition=definition, context=self.context)
-        self.assertEquals(stack.tags, {"environment": "prod", "app": "graph"})
+        self.assertEqual(stack.tags, {"environment": "prod", "app": "graph"})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Deprecated aliases have been removed in python/cpython#28268