### PR TITLE
Allow variable lookups in config dict keys

### DIFF
--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -166,7 +166,8 @@ def substitute_references(root, environment, exp, full_exp):
     elif isinstance(root, dict):
         result = {}
         for k, v in root.items():
-            result[k] = substitute_references(v, environment, exp, full_exp)
+            new_k = substitute_references(k, environment, exp, full_exp)
+            result[new_k] = substitute_references(v, environment, exp, full_exp)
         return result
     elif isstr(root):
         # Strings are the special type where all substitutions happen. If we

--- a/stacker/lookups/__init__.py
+++ b/stacker/lookups/__init__.py
@@ -55,12 +55,14 @@ def extract_lookups(value):
 
     """
     lookups = set()
+
     if isinstance(value, basestring):
         lookups = lookups.union(extract_lookups_from_string(value))
     elif isinstance(value, list):
         for v in value:
             lookups = lookups.union(extract_lookups(v))
     elif isinstance(value, dict):
-        for v in value.values():
+        for k, v in value.items():
+            lookups = lookups.union(extract_lookups(k))
             lookups = lookups.union(extract_lookups(v))
     return lookups

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -67,6 +67,8 @@ class TestConfig(unittest.TestCase):
             substr: prefix-${str_1}-suffix
             multiple: ${str_1}-${str_2}
             dont_match_this: ${output something}
+            key_dict:
+                ${namespace}: foo
         """
         env = """
             namespace: test
@@ -108,6 +110,7 @@ class TestConfig(unittest.TestCase):
         self.assertEquals(pc['substr'], 'prefix-another str-suffix')
         self.assertEquals(pc['multiple'], 'another str-hello')
         self.assertEquals(pc['dont_match_this'], '${output something}')
+        self.assertEquals(pc['key_dict']["test"], 'foo')
 
     def test_render_yaml_errors(self):
         # We shouldn't be able to substitute an object into a string

--- a/stacker/tests/test_lookups.py
+++ b/stacker/tests/test_lookups.py
@@ -35,6 +35,13 @@ class TestLookupExtraction(unittest.TestCase):
         })
         self.assertEqual(len(lookups), 1)
 
+        # Lookups should work in keys as well.
+        lookups = extract_lookups({
+            "${output fakeStack::FakeKeyName}-something": "${output fakeStack::FakeOutput}",
+            "other": "value",
+        })
+        self.assertEqual(len(lookups), 2)
+
     def test_lookups_mixed(self):
         lookups = extract_lookups({
             "something": "${output fakeStack::FakeOutput}",


### PR DESCRIPTION
Sometimes, dict keys need to be generated via lookup, such as for federated IAM policies, where the conditions need to specify outputs of other stacks.

Stacker supported lookup substitution inside dictionary values, and this change extends that behavior to dictionary keys.